### PR TITLE
Handle 'Incorrect Password' exception.

### DIFF
--- a/changes/bug-2640_app-crash-on-wrong-keyring-password
+++ b/changes/bug-2640_app-crash-on-wrong-keyring-password
@@ -1,0 +1,1 @@
+  o Handle 'Incorrect Password' exception (keyring)

--- a/src/leap/gui/mainwindow.py
+++ b/src/leap/gui/mainwindow.py
@@ -354,15 +354,22 @@ class MainWindow(QtGui.QMainWindow):
                 self.ui.chkRemember.setChecked(True)
                 self.ui.chkAutoLogin.setEnabled(self.ui.chkRemember
                                                 .isEnabled())
-                saved_password = keyring.get_password(self.KEYRING_KEY,
-                                                      saved_user
-                                                      .encode("utf8"))
+
+                saved_password = None
+                try:
+                    saved_password = keyring.get_password(self.KEYRING_KEY,
+                                                          saved_user
+                                                          .encode("utf8"))
+                except ValueError, e:
+                    logger.debug("Incorrect Password. %r." % (e,))
+
                 if saved_password is not None:
                     self.ui.lnPassword.setText(saved_password.decode("utf8"))
 
                 # Only automatically login if there is a saved user
+                # and the password was retrieved right
                 self.ui.chkAutoLogin.setChecked(auto_login)
-                if auto_login:
+                if auto_login and saved_password:
                     self._login()
 
     def _show_systray(self):


### PR DESCRIPTION
closes issue #2640.
don not automatic login if there is no password
