### PR TITLE
Wizard ui improvements

### DIFF
--- a/src/leap/gui/ui/wizard.ui
+++ b/src/leap/gui/ui/wizard.ui
@@ -696,6 +696,9 @@
       <property name="alignment">
        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
       </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
      </widget>
     </item>
    </layout>

--- a/src/leap/gui/wizard.py
+++ b/src/leap/gui/wizard.py
@@ -278,6 +278,9 @@ class Wizard(QtGui.QWizard):
 
             self.ui.lblPassword2.clearFocus()
             self._set_registration_fields_visibility(False)
+
+            # Allow the user to remember his password
+            self.ui.chkRemember.setVisible(True)
             self.ui.chkRemember.setEnabled(True)
 
             self.page(self.REGISTER_USER_PAGE).set_completed()
@@ -575,6 +578,7 @@ class Wizard(QtGui.QWizard):
                                                   "%s") %
                                           (self._provider_config
                                            .get_name(),))
+            self.ui.chkRemember.setVisible(False)
 
         if pageId == self.SERVICES_PAGE:
             self._populate_services()


### PR DESCRIPTION
Hide 'remember' checkbox until the registration succeeds.
Use word wrapping to the successful registration message, to be
more long-username-friendly.
