### PR TITLE
Don't autostart EIP if the user explicitly stops the service

### DIFF
--- a/src/leap/config/leapsettings.py
+++ b/src/leap/config/leapsettings.py
@@ -227,10 +227,12 @@ class LeapSettings(object):
         Sets the default provider to be used for autostarting EIP
 
         :param provider: provider to use
-        :type provider: str
+        :type provider: str or None
         """
-        leap_assert(len(provider) > 0, "We cannot save an empty provider")
-        self._settings.setValue(self.DEFAULTPROVIDER_KEY, provider)
+        if provider is None:
+            self._settings.remove(self.DEFAULTPROVIDER_KEY)
+        else:
+            self._settings.setValue(self.DEFAULTPROVIDER_KEY, provider)
 
     def get_alert_missing_scripts(self):
         """

--- a/src/leap/gui/mainwindow.py
+++ b/src/leap/gui/mainwindow.py
@@ -1012,6 +1012,7 @@ class MainWindow(QtGui.QMainWindow):
         self._action_eip_startstop.triggered.connect(
             self._start_eip)
         self._already_started_eip = False
+        self._settings.set_defaultprovider(None)
 
     def _get_best_provider_config(self):
         """


### PR DESCRIPTION
No changes file because it's still an improvement over another previous unreleased improvement
