### PR TITLE
Fix Main Window briefly display on first start.

### DIFF
--- a/changes/bug-2954_fix-mainwindow-show
+++ b/changes/bug-2954_fix-mainwindow-show
@@ -1,0 +1,1 @@
+  o Fix Main Window briefly display before the wizard on first start. Closes Bug #2954.

--- a/src/leap/app.py
+++ b/src/leap/app.py
@@ -151,7 +151,6 @@ def main():
         lambda: twisted_main.quit(app),
         standalone=standalone,
         bypass_checks=bypass_checks)
-    window.show()
 
     sigint_window = partial(sigint_handler, window, logger=logger)
     signal.signal(signal.SIGINT, sigint_window)


### PR DESCRIPTION
Closes Bug #2954. On first start, before displaying the Wizard,
the Main Window briefly showed up.
