### PR TITLE
fix locking for raising window

### DIFF
--- a/changes/bug_fix_raise_window_win
+++ b/changes/bug_fix_raise_window_win
@@ -1,0 +1,2 @@
+  o Fix incorrect handling of locks in windows so that stalled locks do not
+    avoid raising the first instance of the app. Closes: #2910

--- a/src/leap/gui/mainwindow.py
+++ b/src/leap/gui/mainwindow.py
@@ -47,6 +47,7 @@ from leap.services.eip.providerbootstrapper import ProviderBootstrapper
 from leap.services.mail.smtpbootstrapper import SMTPBootstrapper
 from leap.platform_init import IS_WIN, IS_MAC
 from leap.platform_init.initializers import init_platform
+
 from leap.services.eip.vpnprocess import VPN
 
 from leap.services.eip.vpnlaunchers import (VPNLauncherException,
@@ -60,6 +61,7 @@ from leap.services.mail.smtpconfig import SMTPConfig
 
 if IS_WIN:
     from leap.platform_init.locks import WindowsLock
+    from leap.platform_init.locks import raise_window_ack
 
 from ui_mainwindow import Ui_MainWindow
 
@@ -1284,6 +1286,8 @@ class MainWindow(QtGui.QMainWindow):
         """
         Callback for the raise window event
         """
+        if IS_WIN:
+            raise_window_ack()
         self.raise_window.emit()
 
     def _do_raise_mainwindow(self):
@@ -1309,8 +1313,7 @@ class MainWindow(QtGui.QMainWindow):
         Triggered after aboutToQuit signal.
         """
         if IS_WIN:
-            lockfile = WindowsLock()
-            lockfile.release_lock()
+            WindowsLock.release_all_locks()
 
     def _cleanup_and_quit(self):
         """

--- a/src/leap/services/eip/vpnlaunchers.py
+++ b/src/leap/services/eip/vpnlaunchers.py
@@ -535,8 +535,8 @@ class DarwinVPNLauncher(VPNLauncher):
     def get_cocoasudo_installmissing_cmd(self):
         """
         Returns a string with the cocoasudo command needed to install missing
-        files as admin with a nice password prompt. The actual command needs to be
-        appended.
+        files as admin with a nice password prompt. The actual command needs to
+        be appended.
 
         :rtype: (str, list)
         """

--- a/src/leap/util/__init__.py
+++ b/src/leap/util/__init__.py
@@ -15,8 +15,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
-Initializes version and app info
+Initializes version and app info, plus some small and handy functions.
 """
+import datetime
+import os
 
 __version__ = "unknown"
 try:
@@ -47,3 +49,29 @@ def first(things):
         return things[0]
     except TypeError:
         return None
+
+
+def get_modification_ts(path):
+    """
+    Gets modification time of a file.
+
+    :param path: the path to get ts from
+    :type path: str
+    :returns: modification time
+    :rtype: datetime object
+    """
+    ts = os.path.getmtime(path)
+    return datetime.datetime.fromtimestamp(ts)
+
+
+def update_modification_ts(path):
+    """
+    Sets modification time of a file to current time.
+
+    :param path: the path to set ts to.
+    :type path: str
+    :returns: modification time
+    :rtype: datetime object
+    """
+    os.utime(path, None)
+    return get_modification_ts(path)


### PR DESCRIPTION
under windows.
After some work with the ack and hitting some troubles with the callbacks, I thought we can use the lockdir properties to signal the callback and make the 2nd instance aware of the fact that the 1st is alive and operative. I do believe this ends up being functional and simple enough for our purpose.
