### PR TITLE
Fix local offset calculation. Closes #3595.

### DIFF
--- a/changes/bug-3595_fix-gateway-selection-problem
+++ b/changes/bug-3595_fix-gateway-selection-problem
@@ -1,0 +1,1 @@
+  o Fix gateway selection problem. Closes 3595.

--- a/src/leap/bitmask/services/eip/eipconfig.py
+++ b/src/leap/bitmask/services/eip/eipconfig.py
@@ -141,7 +141,7 @@ class VPNGatewaySelector(object):
         if time.daylight:
             local_offset = time.altzone
 
-        return local_offset / 3600
+        return -local_offset / 3600
 
 
 class EIPConfig(BaseConfig):


### PR DESCRIPTION
Python returns the timezone with the opposed sign to the standard
notation.
