### PR TITLE
Fix save log dialog freezing. Closes #3675.

### DIFF
--- a/changes/bug-3675_qfiledialog-and-qtreactor-freezes
+++ b/changes/bug-3675_qfiledialog-and-qtreactor-freezes
@@ -1,0 +1,1 @@
+  o Fix save logs to file dialog freezing. Closes #3675.

--- a/src/leap/bitmask/gui/loggerwindow.py
+++ b/src/leap/bitmask/gui/loggerwindow.py
@@ -146,7 +146,8 @@ class LoggerWindow(QtGui.QDialog):
         Lets the user save the current log to a file
         """
         fileName, filtr = QtGui.QFileDialog.getSaveFileName(
-            self, self.tr("Save As"))
+            self, self.tr("Save As"),
+            options=QtGui.QFileDialog.DontUseNativeDialog)
 
         if fileName:
             try:


### PR DESCRIPTION
Avoid using native dialog seems to solve the QFileDialog freezing when
qtreactor is used.
See more at: http://www.code-corner.de/?p=171
