### PR TITLE
Change the order of the actions in the release.

### DIFF
--- a/docs/release_checklist.wiki
+++ b/docs/release_checklist.wiki
@@ -21,10 +21,10 @@
     * [ ] Review pkg/requirements.pip for everything and update if needed (that's why the order).
       - See whatever has been introduced in changes/VERSION_COMPAT
       - Reset changes/VERSION_COMPAT
+    * [ ] git checkout master && git pull origin master && git merge --no-ff release-X.Y.Z && git push origin master
+    * [ ] git checkout develop && git pull origin develop && git merge --no-ff release-X.Y.Z && git push origin develop
     * [ ] git tag -s X.Y.Z (note the -s so that it's a signed tag) The message should be something like: Tag <package> version X.Y.Z
     * [ ] git push origin X.Y.Z
-    * [ ] git checkout master && git pull origin master && git merge release-X.Y.Z && git push origin master
-    * [ ] git checkout develop && git pull origin develop && git merge release-X.Y.Z && git push origin develop
   * [ ] Build and upload bundles
     * [ ] Use the scripts under pkg/<os>/ to build the the bundles.
     * [ ] Sign them with gpg -a --sign --detach-sign <path/to/bundle>
@@ -38,3 +38,5 @@
 Notes
 -----
 (*) this checklist kindly borrowed from tahoe-lafs documentation =)
+
+For a good reference look at http://nvie.com/posts/a-successful-git-branching-model/


### PR DESCRIPTION
With this change we are following more accurately:
http://nvie.com/posts/a-successful-git-branching-model/

Also, we achieve a clean version in master.
If we do the tag before the merge in master, then we would have an extra
commit after the tagging, which causes version to be X.Y.Z-1-blah.
