### PR TITLE
Update instructions to improve release process.

### DIFF
--- a/docs/release_checklist.wiki
+++ b/docs/release_checklist.wiki
@@ -22,9 +22,9 @@
       - See whatever has been introduced in changes/VERSION_COMPAT
       - Reset changes/VERSION_COMPAT
     * [ ] git checkout master && git pull origin master && git merge --no-ff release-X.Y.Z && git push origin master
-    * [ ] git checkout develop && git pull origin develop && git merge --no-ff release-X.Y.Z && git push origin develop
-    * [ ] git tag -s X.Y.Z (note the -s so that it's a signed tag) The message should be something like: Tag <package> version X.Y.Z
+    * [ ] git tag -s X.Y.Z  -m "Tag <package> version X.Y.Z" # (note the -s so that it's a signed tag and -m to specify the message for the tag)
     * [ ] git push origin X.Y.Z
+    * [ ] git checkout develop && git merge master && git push origin develop
   * [ ] Build and upload bundles
     * [ ] Use the scripts under pkg/<os>/ to build the the bundles.
     * [ ] Sign them with gpg -a --sign --detach-sign <path/to/bundle>


### PR DESCRIPTION
This allows us to have master and develop in sync after the release.
Also get a correct and clean version report.

I've included the `-m` switch in the `git tag` command so we avoid to
open an editor and let us closer to make a script to automate this.
