### PR TITLE
Reorder providers combo, disable if no providers.

### DIFF
--- a/src/leap/bitmask/gui/ui/wizard.ui
+++ b/src/leap/bitmask/gui/ui/wizard.ui
@@ -269,7 +269,24 @@
        <string>Configure or select a provider</string>
       </property>
       <layout class="QGridLayout" name="gridLayout_5">
-       <item row="0" column="1">
+       <item row="0" column="0">
+        <widget class="QRadioButton" name="rbNewProvider">
+         <property name="text">
+          <string>Configure new provider:</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QRadioButton" name="rbExistingProvider">
+         <property name="text">
+          <string>Use existing one:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
         <widget class="QLabel" name="label">
          <property name="text">
           <string>https://</string>
@@ -279,44 +296,30 @@
          </property>
         </widget>
        </item>
-       <item row="0" column="2">
+       <item row="1" column="1">
         <widget class="QLineEdit" name="lnProvider"/>
        </item>
        <item row="1" column="2">
-        <widget class="QComboBox" name="cbProviders">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="3">
         <widget class="QPushButton" name="btnCheck">
          <property name="text">
           <string>Check</string>
          </property>
         </widget>
        </item>
-       <item row="0" column="0">
-        <widget class="QRadioButton" name="rbNewProvider">
-         <property name="text">
-          <string>Configure new provider</string>
-         </property>
-         <property name="checked">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <widget class="QRadioButton" name="rbExistingProvider">
-         <property name="text">
-          <string>Use existing one</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="1">
+       <item row="3" column="0">
         <widget class="QLabel" name="label_8">
          <property name="text">
           <string>https://</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QComboBox" name="cbProviders">
+         <property name="enabled">
+          <bool>false</bool>
          </property>
         </widget>
        </item>

--- a/src/leap/bitmask/gui/wizard.py
+++ b/src/leap/bitmask/gui/wizard.py
@@ -155,6 +155,12 @@ class Wizard(QtGui.QWizard):
         """
         ls = LeapSettings()
         providers = ls.get_configured_providers()
+        if not providers:
+            self.ui.rbExistingProvider.setEnabled(False)
+            self.ui.label_8.setEnabled(False)  # 'https://' label
+            self.ui.cbProviders.setEnabled(False)
+            return
+
         pinned = []
         user_added = []
 


### PR DESCRIPTION
- Move radio buttons to get more space for the labels.
- If there are no configured providers then disable the combo.
