### PR TITLE
Show more context information in the logs.

### DIFF
--- a/changes/feature-3923_more-verbose-logs
+++ b/changes/feature-3923_more-verbose-logs
@@ -1,0 +1,1 @@
+  o Show more context information in the logs. Closes #3923.

--- a/src/leap/bitmask/app.py
+++ b/src/leap/bitmask/app.py
@@ -99,7 +99,7 @@ def add_logger_handlers(debug=False, logfile=None):
     logger = logging.getLogger(name='leap')
     logger.setLevel(level)
 
-    log_format = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    log_format = '%(asctime)s - %(name)s:%(funcName)s:L#%(lineno)s - %(levelname)s - %(message)s'
     formatter = logging.Formatter(log_format)
 
     # Console handler

--- a/src/leap/bitmask/util/leap_log_handler.py
+++ b/src/leap/bitmask/util/leap_log_handler.py
@@ -52,7 +52,7 @@ class LogHandler(logging.Handler):
         :param logging_level: the debug level to define the color.
         :type logging_level: str.
         """
-        log_format = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+        log_format = '%(asctime)s - %(name)s:%(funcName)s:L#%(lineno)s - %(levelname)s - %(message)s'
         formatter = logging.Formatter(log_format)
 
         return formatter


### PR DESCRIPTION
Add line numbers and function name from where the log is displayed.
