### PR TITLE
Always display first run wizard on first run.

### DIFF
--- a/changes/bug-4143_display-firstrun
+++ b/changes/bug-4143_display-firstrun
@@ -1,0 +1,1 @@
+  o Display first run wizard, regardless of pinned providers. Closes #4143.

--- a/src/leap/bitmask/config/leapsettings.py
+++ b/src/leap/bitmask/config/leapsettings.py
@@ -69,6 +69,7 @@ class LeapSettings(object):
     ALERTMISSING_KEY = "AlertMissingScripts"
     GATEWAY_KEY = "Gateway"
     PINNED_KEY = "Pinned"
+    SKIPFIRSTRUN_KEY = "SkipFirstRun"
 
     # values
     GATEWAY_AUTOMATIC = "Automatic"
@@ -260,29 +261,6 @@ class LeapSettings(object):
         leap_assert_type(remember, bool)
         self._settings.setValue(self.REMEMBER_KEY, remember)
 
-    # TODO: make this scale with multiple providers, we are assuming
-    # just one for now
-    def get_properprovider(self):
-        """
-        Returns True if there is a properly configured provider.
-
-        .. note:: this assumes only one provider for now.
-
-        :rtype: bool
-        """
-        return to_bool(self._settings.value(self.PROPERPROVIDER_KEY, False))
-
-    def set_properprovider(self, properprovider):
-        """
-        Sets whether the app should automatically login.
-
-        :param properprovider: True if the provider is properly configured,
-            False otherwise.
-        :type properprovider: bool
-        """
-        leap_assert_type(properprovider, bool)
-        self._settings.setValue(self.PROPERPROVIDER_KEY, properprovider)
-
     def get_defaultprovider(self):
         """
         Returns the default provider to be used for autostarting EIP
@@ -338,3 +316,22 @@ class LeapSettings(object):
         """
         leap_assert_type(value, bool)
         self._settings.setValue(self.ALERTMISSING_KEY, value)
+
+    def get_skip_first_run(self):
+        """
+        Gets the setting for skip running the first run wizard.
+
+        :returns: if the first run wizard should be skipped or not
+        :rtype: bool
+        """
+        return to_bool(self._settings.value(self.SKIPFIRSTRUN_KEY, False))
+
+    def set_skip_first_run(self, skip):
+        """
+        Gets the setting for skip the first run wizard.
+
+        :param skip: if the first run wizard should be skipped or not
+        :type skip: bool
+        """
+        leap_assert_type(skip, bool)
+        self._settings.setValue(self.SKIPFIRSTRUN_KEY, skip)

--- a/src/leap/bitmask/gui/mainwindow.py
+++ b/src/leap/bitmask/gui/mainwindow.py
@@ -365,7 +365,12 @@ class MainWindow(QtGui.QMainWindow):
         """
         if self._wizard_firstrun:
             self._settings.set_properprovider(False)
-            self.quit()
+            providers = self._settings.get_configured_providers()
+            has_provider_on_disk = len(providers) != 0
+            if not has_provider_on_disk:
+                # if we don't have any provider configured (included a pinned
+                # one) we can't use the application, so quit.
+                self.quit()
         else:
             self._finish_init()
 
@@ -393,6 +398,7 @@ class MainWindow(QtGui.QMainWindow):
         if IS_MAC:
             self._wizard.raise_()
         self._wizard.finished.connect(self._wizard_finished)
+        self._settings.set_skip_first_run(True)
 
     def _wizard_finished(self):
         """
@@ -783,8 +789,8 @@ class MainWindow(QtGui.QMainWindow):
         """
         providers = self._settings.get_configured_providers()
         has_provider_on_disk = len(providers) != 0
-        is_proper_provider = self._settings.get_properprovider()
-        return not (has_provider_on_disk and is_proper_provider)
+        skip_first_run = self._settings.get_skip_first_run()
+        return not (has_provider_on_disk and skip_first_run)
 
     def _download_provider_config(self):
         """


### PR DESCRIPTION
- Display the wizard only the first time or if we don't have any provider
  configured.
- Remove unused proper provider setting.
- If we have a working provider (as a pinned one), the wizard won't show
  automatically after being displayed the first time.
- If we cancel the first time wizard and we have a configured provider
  (like the pinned one) the app will not close.
