### PR TITLE
Support html logs in the logger window.

### DIFF
--- a/changes/bug-4146_logger-window-html-support
+++ b/changes/bug-4146_logger-window-html-support
@@ -1,0 +1,2 @@
+- Escape logs with html contents so they get displayed in plaintext
+  on the log viewer. Closes #4146.

--- a/src/leap/bitmask/gui/loggerwindow.py
+++ b/src/leap/bitmask/gui/loggerwindow.py
@@ -19,6 +19,7 @@
 History log window
 """
 import logging
+import cgi
 
 from PySide import QtGui
 
@@ -90,7 +91,7 @@ class LoggerWindow(QtGui.QDialog):
             logging.CRITICAL: "background: red; color: white; font: bold;"
         }
         level = log[LeapLogHandler.RECORD_KEY].levelno
-        message = log[LeapLogHandler.MESSAGE_KEY]
+        message = cgi.escape(log[LeapLogHandler.MESSAGE_KEY])
 
         if self._logs_to_display[level]:
             open_tag = "<tr style='" + html_style[level] + "'>"


### PR DESCRIPTION
Escape special characters to display them correctly in the logger window.

[Closes #4146]
