### PR TITLE
Check if we have a systray to use.

### DIFF
--- a/src/leap/bitmask/gui/eip_status.py
+++ b/src/leap/bitmask/gui/eip_status.py
@@ -197,8 +197,10 @@ class EIPStatusWidget(QtGui.QWidget):
         """
         Updates the system tray tooltip using the eip status.
         """
-        eip_status = u"{0}: {1}".format(self._service_name, self._eip_status)
-        self._systray.set_service_tooltip(EIP_SERVICE, eip_status)
+        if self._systray is not None:
+            eip_status = u"{0}: {1}".format(
+                self._service_name, self._eip_status)
+            self._systray.set_service_tooltip(EIP_SERVICE, eip_status)
 
     def set_action_eip_startstop(self, action_eip_startstop):
         """

--- a/src/leap/bitmask/gui/mail_status.py
+++ b/src/leap/bitmask/gui/mail_status.py
@@ -166,8 +166,9 @@ class MailStatusWidget(QtGui.QWidget):
         """
         Updates the system tray tooltip using the mx status.
         """
-        mx_status = u"{0}: {1}".format(self._service_name, self._mx_status)
-        self._systray.set_service_tooltip(MX_SERVICE, mx_status)
+        if self._systray is not None:
+            mx_status = u"{0}: {1}".format(self._service_name, self._mx_status)
+            self._systray.set_service_tooltip(MX_SERVICE, mx_status)
 
     def set_action_mail_status(self, action_mail_status):
         """


### PR DESCRIPTION
This fixes a failure when we run the first run wizard and don't have a
systray ready.
