### PR TITLE
Select the provider selected in the login widget.

### DIFF
--- a/changes/4490_preferences-selects-current-login-widget-provider
+++ b/changes/4490_preferences-selects-current-login-widget-provider
@@ -1,0 +1,2 @@
+- Make the preferences window selects the current selected provider in the
+  login widget even if the user is not logged in. Closes #4490.

--- a/src/leap/bitmask/gui/mainwindow.py
+++ b/src/leap/bitmask/gui/mainwindow.py
@@ -467,9 +467,9 @@ class MainWindow(QtGui.QMainWindow):
 
         Displays the preferences window.
         """
-        preferences_window = PreferencesWindow(self, self._srp_auth,
-                                               self._provider_config,
-                                               self._soledad)
+        preferences_window = PreferencesWindow(
+            self, self._srp_auth, self._provider_config, self._soledad,
+            self._login_widget.get_selected_provider())
 
         self.soledad_ready.connect(preferences_window.set_soledad_ready)
         preferences_window.show()

--- a/src/leap/bitmask/gui/preferenceswindow.py
+++ b/src/leap/bitmask/gui/preferenceswindow.py
@@ -42,7 +42,7 @@ class PreferencesWindow(QtGui.QDialog):
     """
     Window that displays the preferences.
     """
-    def __init__(self, parent, srp_auth, provider_config, soledad):
+    def __init__(self, parent, srp_auth, provider_config, soledad, domain):
         """
         :param parent: parent object of the PreferencesWindow.
         :parent type: QWidget
@@ -52,6 +52,8 @@ class PreferencesWindow(QtGui.QDialog):
         :type provider_config: ProviderConfig
         :param soledad: Soledad instance
         :type soledad: Soledad
+        :param domain: the selected domain in the login widget
+        :type domain: unicode
         """
         QtGui.QDialog.__init__(self, parent)
         self.AUTOMATIC_GATEWAY_LABEL = self.tr("Automatic")
@@ -83,9 +85,6 @@ class PreferencesWindow(QtGui.QDialog):
         # check if the user is logged in
         if srp_auth is not None and srp_auth.get_token() is not None:
             # check if provider has 'mx' ...
-            domain = provider_config.get_domain()
-            self._select_provider_by_name(domain)
-
             if provider_config.provides_mx():
                 enabled_services = self._settings.get_enabled_services(domain)
                 mx_name = get_service_display_name(MX_SERVICE)
@@ -110,6 +109,8 @@ class PreferencesWindow(QtGui.QDialog):
             msg = self.tr(
                 "In order to change your password you need to be logged in.")
             self._set_password_change_status(msg)
+
+        self._select_provider_by_name(domain)
 
         self.ui.gbPasswordChange.setEnabled(pw_enabled)
 


### PR DESCRIPTION
In the preferences window, now we select the current provider from the
login widget, no matter if the user is logged in or not.

[Closes #4490]
