### PR TITLE
Reset registration error and input widgets.

### DIFF
--- a/changes/bug-4742_reset-registration-page-error
+++ b/changes/bug-4742_reset-registration-page-error
@@ -1,0 +1,2 @@
+- Reset registration error and input widgets if the user goes back to provider
+  selection in wizard. Closes #4742.

--- a/src/leap/bitmask/gui/wizard.py
+++ b/src/leap/bitmask/gui/wizard.py
@@ -597,6 +597,7 @@ class Wizard(QtGui.QWizard):
         Prepares the pages when they appear
         """
         if pageId == self.SELECT_PROVIDER_PAGE:
+            self._clear_register_widgets()
             skip = self.ui.rbExistingProvider.isChecked()
             if not self._provider_checks_ok:
                 self._enable_check()
@@ -670,3 +671,12 @@ class Wizard(QtGui.QWizard):
                     return self.SERVICES_PAGE
 
         return QtGui.QWizard.nextId(self)
+
+    def _clear_register_widgets(self):
+        """
+        Clears the widgets that my be filled and a possible error message.
+        """
+        self._set_register_status("")
+        self.ui.lblUser.setText("")
+        self.ui.lblPassword.setText("")
+        self.ui.lblPassword2.setText("")


### PR DESCRIPTION
The registration widgets are cleared if the user goes back to the
provider selection page.

[Closes #4742]
