### PR TITLE
Avoids permanent break of resolv.conf.

### DIFF
--- a/changes/bug-4633_fix-resolvconf-usage
+++ b/changes/bug-4633_fix-resolvconf-usage
@@ -1,0 +1,1 @@
+- Correct resolvconf usage. Avoids permanent break of resolv.conf. Closes #4633.

--- a/pkg/linux/resolv-update
+++ b/pkg/linux/resolv-update
@@ -70,7 +70,7 @@ SETVAR
           R="${R}nameserver $NS
 "
   done
-  mv /etc/resolv.conf /etc/resolv.conf.bak
+  cp /etc/resolv.conf /etc/resolv.conf.bak
   echo "$comment
 $custom_head
 $R
@@ -79,8 +79,8 @@ $custom_tail" > /etc/resolv.conf
 
 function down() {
   if [ -f /etc/resolv.conf.bak ] ; then
-    unlink /etc/resolv.conf
-    mv /etc/resolv.conf.bak /etc/resolv.conf
+    cat /etc/resolv.conf.bak > /etc/resolv.conf
+    rm /etc/resolv.conf.bak
   fi
 }
 


### PR DESCRIPTION
The resolv.conf file gets updated by resolvconf, maintaining it as a
symlink allows the system to reset it during boot time. That is useful
when the app has a hard crash that gives no chance to roll back our
changes.

[Closes #4633]
