### PR TITLE
defend against keyring errors

### DIFF
--- a/changes/bug_capture-keyring-errors
+++ b/changes/bug_capture-keyring-errors
@@ -1,0 +1,2 @@
+- Fail gracefully against keyring import errors.
+


### PR DESCRIPTION
on certain settings, like a virtualenv with symlinks, I'm getting
errors after a suspend, related to a error to connect to the dbus
socket.

wrapping all of it in a conditional we avoid that kind of error.
