### PR TITLE
Take care of None value for the uuid.

### DIFF
--- a/changes/bug-4995_error-on-every-logout
+++ b/changes/bug-4995_error-on-every-logout
@@ -1,0 +1,1 @@
+- Fix "Something went wrong with the logout" misleading error in every logout. Closes #4995 and #5071.

--- a/src/leap/bitmask/config/leapsettings.py
+++ b/src/leap/bitmask/config/leapsettings.py
@@ -372,12 +372,16 @@ class LeapSettings(object):
         Sets the uuid for a given username.
 
         :param username: the full user identifier in the form user@provider
-        :type username: basestring
-        :param value: the uuid to save
-        :type value: basestring
+        :type username: str or unicode
+        :param value: the uuid to save or None to remove it
+        :type value: str or unicode or None
         """
         leap_assert("@" in username,
                     "Expected username in the form user@provider")
         user, provider = username.split('@')
-        leap_assert(len(value) > 0, "We cannot save an empty uuid")
-        self._settings.setValue(self.UUIDFORUSER_KEY % (provider, user), value)
+        key = self.UUIDFORUSER_KEY % (provider, user)
+        if value is None:
+            self._settings.remove(key)
+        else:
+            leap_assert(len(value) > 0, "We cannot save an empty uuid")
+            self._settings.setValue(key, value)


### PR DESCRIPTION
Receiving a None value was raising an exception that didn't show up
since was trapped inside the srpauth:logout method.

[Closes #4995]
[Closes #5071]
