### PR TITLE
Properly handle defer cancelling.

### DIFF
--- a/changes/bug_cancel-login-does-not-work
+++ b/changes/bug_cancel-login-does-not-work
@@ -1,0 +1,1 @@
+- Cancel login does not work or needs to be pressed twice. Closes #4869, #4973.

--- a/src/leap/bitmask/crypto/srpauth.py
+++ b/src/leap/bitmask/crypto/srpauth.py
@@ -655,7 +655,6 @@ class SRPAuth(QtCore.QObject):
         username = username.lower()
         d = self.__instance.authenticate(username, password)
         d.addCallback(self._gui_notify)
-        d.addErrback(self._errback)
         return d
 
     def change_password(self, current_password, new_password):
@@ -694,18 +693,6 @@ class SRPAuth(QtCore.QObject):
         """
         logger.debug("Successful login!")
         self.authentication_finished.emit(True, self.tr("Succeeded"))
-
-    def _errback(self, failure):
-        """
-        General errback for the whole login process. Will notify the
-        UI with the proper signal.
-
-        :param failure: Failure object captured from a callback.
-        :type failure: twisted.python.failure.Failure
-        """
-        logger.error("Error logging in %s" % (failure,))
-        self.authentication_finished.emit(False, "%s" % (failure.value,))
-        failure.trap(Exception)
 
     def get_session_id(self):
         return self.__instance.get_session_id()

--- a/src/leap/bitmask/services/abstractbootstrapper.py
+++ b/src/leap/bitmask/services/abstractbootstrapper.py
@@ -28,6 +28,7 @@ from PySide import QtCore
 
 from twisted.python import log
 from twisted.internet import threads
+from twisted.internet.defer import CancelledError
 
 from leap.common.check import leap_assert, leap_assert_type
 
@@ -91,6 +92,12 @@ class AbstractBootstrapper(QtCore.QObject):
         :param failure: failure object that Twisted generates
         :type failure: twisted.python.failure.Failure
         """
+        if failure.check(CancelledError):
+            logger.debug("Defer cancelled.")
+            failure.trap(Exception)
+            self._signaler.signal(self._signaler.PROV_CANCELLED_SETUP)
+            return
+
         if self._signal_to_emit:
             err_msg = self._err_msg \
                 if self._err_msg is not None \

--- a/src/leap/bitmask/services/soledad/soledadbootstrapper.py
+++ b/src/leap/bitmask/services/soledad/soledadbootstrapper.py
@@ -617,4 +617,4 @@ class SoledadBootstrapper(AbstractBootstrapper):
             (self._gen_key, self.gen_key)
         ]
 
-        self.addCallbackChain(cb_chain)
+        return self.addCallbackChain(cb_chain)


### PR DESCRIPTION
- Fix issues related to "Cancel login does not work".
- Move srpauth errback to mainwindow.
- Add signal for provider setup cancel.
- Add support to cancel the soledad defer.

[Closes #4869]
[Closes #4973]
