### PR TITLE
Do version checks in the wizard too.

### DIFF
--- a/changes/bug-5048_version-checks-in-wizard
+++ b/changes/bug-5048_version-checks-in-wizard
@@ -1,0 +1,1 @@
+- Use version checks in the wizard when the user choose to use an existing provider. Closes #5048.

--- a/src/leap/bitmask/gui/ui/wizard.ui
+++ b/src/leap/bitmask/gui/ui/wizard.ui
@@ -269,20 +269,7 @@
        <string>Configure or select a provider</string>
       </property>
       <layout class="QGridLayout" name="gridLayout_5">
-       <item row="5" column="1">
-        <widget class="QLineEdit" name="lnProvider"/>
-       </item>
-       <item row="5" column="0">
-        <widget class="QLabel" name="label">
-         <property name="text">
-          <string>https://</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="0">
+       <item row="1" column="0">
         <widget class="QRadioButton" name="rbNewProvider">
          <property name="text">
           <string>Configure new provider:</string>
@@ -292,14 +279,27 @@
          </property>
         </widget>
        </item>
-       <item row="5" column="2">
-        <widget class="QPushButton" name="btnCheck">
-         <property name="text">
-          <string>Check</string>
+       <item row="0" column="2">
+        <widget class="QComboBox" name="cbProviders">
+         <property name="enabled">
+          <bool>false</bool>
          </property>
         </widget>
        </item>
-       <item row="2" column="0">
+       <item row="1" column="1">
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>https://</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="2">
+        <widget class="QLineEdit" name="lnProvider"/>
+       </item>
+       <item row="0" column="0">
         <widget class="QRadioButton" name="rbExistingProvider">
          <property name="text">
           <string>Use existing one:</string>
@@ -309,7 +309,7 @@
          </property>
         </widget>
        </item>
-       <item row="3" column="0">
+       <item row="0" column="1">
         <widget class="QLabel" name="label_8">
          <property name="text">
           <string>https://</string>
@@ -319,12 +319,29 @@
          </property>
         </widget>
        </item>
-       <item row="3" column="1">
-        <widget class="QComboBox" name="cbProviders">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-        </widget>
+       <item row="2" column="2">
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <item>
+          <spacer name="horizontalSpacer_3">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QPushButton" name="btnCheck">
+           <property name="text">
+            <string>Check</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
       </layout>
      </widget>
@@ -859,8 +876,8 @@
      <y>174</y>
     </hint>
     <hint type="destinationlabel">
-     <x>454</x>
-     <y>254</y>
+     <x>450</x>
+     <y>266</y>
     </hint>
    </hints>
   </connection>
@@ -884,7 +901,7 @@
    <sender>rbExistingProvider</sender>
    <signal>toggled(bool)</signal>
    <receiver>btnCheck</receiver>
-   <slot>setDisabled(bool)</slot>
+   <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>169</x>

--- a/src/leap/bitmask/gui/wizard.py
+++ b/src/leap/bitmask/gui/wizard.py
@@ -223,7 +223,7 @@ class Wizard(QtGui.QWizard):
         depending on the lnProvider content.
         """
         enabled = len(self.ui.lnProvider.text()) != 0
-        enabled = enabled and self.ui.rbNewProvider.isChecked()
+        enabled = enabled or self.ui.rbExistingProvider.isChecked()
         self.ui.btnCheck.setEnabled(enabled)
 
         if reset:
@@ -367,8 +367,10 @@ class Wizard(QtGui.QWizard):
 
         Starts the checks for a given provider
         """
-        if len(self.ui.lnProvider.text()) == 0:
-            return
+        if self.ui.rbNewProvider.isChecked():
+            self._domain = self.ui.lnProvider.text()
+        else:
+            self._domain = self.ui.cbProviders.currentText()
 
         self._provider_checks_ok = False
 
@@ -380,7 +382,6 @@ class Wizard(QtGui.QWizard):
         self.ui.btnCheck.setEnabled(False)
         self.ui.lnProvider.setEnabled(False)
         self.button(QtGui.QWizard.BackButton).clearFocus()
-        self._domain = self.ui.lnProvider.text()
 
         self.ui.lblNameResolution.setPixmap(self.QUESTION_ICON)
         self._provider_select_defer = self._backend.\
@@ -401,8 +402,6 @@ class Wizard(QtGui.QWizard):
         if skip:
             self._reset_provider_check()
 
-        self.page(self.SELECT_PROVIDER_PAGE).set_completed(skip)
-        self.button(QtGui.QWizard.NextButton).setEnabled(skip)
         self._use_existing_provider = skip
 
     def _complete_task(self, data, label, complete=False, complete_page=-1):


### PR DESCRIPTION
When the user choose to use an existing provider we download the
provider.json again so the version checks are executed.

[Closes #5048]
