### PR TITLE
Run all the soledad bootstrap on error.

### DIFF
--- a/changes/better-soledad-retry
+++ b/changes/better-soledad-retry
@@ -1,0 +1,1 @@
+In case of soledad bootstrap error (e.g.: network failure), re run all the setup process.

--- a/src/leap/bitmask/gui/mainwindow.py
+++ b/src/leap/bitmask/gui/mainwindow.py
@@ -1247,8 +1247,7 @@ class MainWindow(QtGui.QMainWindow):
             self._soledad_bootstrapper.increment_retries_count()
             # XXX should cancel the existing socket --- this
             # is avoiding a clean termination.
-            threads.deferToThread(
-                self._soledad_bootstrapper.load_and_sync_soledad)
+            self._maybe_run_soledad_setup_checks()
         else:
             logger.warning("Max number of soledad initialization "
                            "retries reached.")


### PR DESCRIPTION
Before this fix, if the soledad bootstrapping failed during the first
download process, we retried since after that point which caused a
failure.

To reproduce the problem before and after this fix you can use this diff:

``` diff
diff --git a/src/leap/bitmask/services/soledad/soledadbootstrapper.py b/src/leap/bitmask/services/soledad/soledadbootstrapper.py
index 7aa86a0..b7ee646 100644
--- a/src/leap/bitmask/services/soledad/soledadbootstrapper.py
+++ b/src/leap/bitmask/services/soledad/soledadbootstrapper.py
@@ -159,6 +159,8 @@ class SoledadBootstrapper(AbstractBootstrapper):

         self._soledad_retries = 0

+        self._fake_exc = True
+
     @property
     def keymanager(self):
         return self._keymanager
@@ -453,6 +455,9 @@ class SoledadBootstrapper(AbstractBootstrapper):
         """
         Download the Soledad config for the given provider
         """
+        if self._fake_exc:
+            self._fake_exc = False
+            raise Exception("Fake problem")

         leap_assert(self._provider_config,
                     "We need a provider configuration!")
```
