### PR TITLE
Pin psutil version to avoid conflicts with gnupg.

### DIFF
--- a/changes/bug-5309_psutil-version-conflict
+++ b/changes/bug-5309_psutil-version-conflict
@@ -1,0 +1,1 @@
+- Fix psutil version to avoid conflicts with gnupg required version. Closes #5309.

--- a/pkg/requirements.pip
+++ b/pkg/requirements.pip
@@ -10,7 +10,7 @@ requests>=1.1.0
 srp>=1.0.2
 pyopenssl
 python-dateutil
-psutil
+psutil==1.2.1
 ipaddr
 twisted
 python-daemon # this should not be needed for Windows.


### PR DESCRIPTION
gnupg 1.2.5 requires psutil==1.2.1

Closes #5309.
