### PR TITLE
Add script to sum changes status.

### DIFF
--- a/pkg/scripts/stats.sh
+++ b/pkg/scripts/stats.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+REPOSITORIES="bitmask_client leap_pycommon soledad keymanager leap_mail"
+
+CHANGED=0
+INSERTIONS=0
+DELETIONS=0
+MERGES_TOTAL=0
+
+echo "Changes summary between closest annotated tag to HEAD"
+echo "====================================================="
+echo
+
+for repo in $REPOSITORIES; do
+    cd $repo
+    echo "Stats for: $repo"
+    # the 'describe' command gives the closest annotated tag
+    STATS=$(git diff --shortstat `git describe --abbrev=0`..HEAD)
+    MERGES=$(git log --merges `git describe --abbrev=0`..HEAD | wc -l)
+    echo "Stats:$STATS"
+    echo "Merges: $MERGES"
+    VALUES=(`echo $STATS | awk '{ print $1, $4, $6 }'`)  # use array to store values
+    CHANGED=$(echo $CHANGED + ${VALUES[0]} | bc)
+    INSERTIONS=$(echo $INSERTIONS + ${VALUES[1]} | bc)
+    DELETIONS=$(echo $DELETIONS + ${VALUES[2]} | bc)
+    MERGES_TOTAL=$(echo $MERGES_TOTAL + $MERGES | bc)
+    echo "----------------------------------------------------------------------"
+    cd ..
+done
+
+echo
+echo "TOTAL"
+echo "Stats: $CHANGED files changed, $INSERTIONS insertions(+), $DELETIONS deletions(-)"
+echo "Merges: $MERGES_TOTAL"


### PR DESCRIPTION
This script gives a summary of changes since the latest annotated tag.
Example output:

```
ivan in [/mnt/datos/Unixono/proyectos/LEAP]                                                                                                                      [45/9919]
(venv:bitmask) ➜ ./stats.sh 
Changes summary between closest annotated tag to HEAD
=====================================================

Stats for: bitmask_client
Stats: 116 files changed, 4316 insertions(+), 1377 deletions(-)
Merges: 559
----------------------------------------------------------------------
Stats for: leap_pycommon
Stats: 10 files changed, 263 insertions(+), 18 deletions(-)
Merges: 34
----------------------------------------------------------------------
Stats for: soledad
Stats: 84 files changed, 5104 insertions(+), 1375 deletions(-)
Merges: 216
----------------------------------------------------------------------
Stats for: keymanager
Stats: 12 files changed, 104 insertions(+), 66 deletions(-)
Merges: 76
----------------------------------------------------------------------
Stats for: leap_mail
Stats: 71 files changed, 9478 insertions(+), 2156 deletions(-)
Merges: 412
----------------------------------------------------------------------

TOTAL
Stats: 293 files changed, 19265 insertions(+), 4992 deletions(-)
Merges: 1297
```
