### PR TITLE
Use non blocking dialog for Pastebin result

### DIFF
--- a/changes/bug-5404_pastebin-dialog-blocks-app
+++ b/changes/bug-5404_pastebin-dialog-blocks-app
@@ -1,0 +1,1 @@
+- Use non blocking dialog so the Pastebin result does not block the app. Closes #5404.


### PR DESCRIPTION
With this change we no longer need to call the dialog with reactor.callLater.
Also removed useless failure.trap

Closes #5404.
