### PR TITLE
Add checks to avoid errors when ctrl-c in wizard.

### DIFF
--- a/changes/bug-5559_avoid-errors-when-ctrl-c-wizard
+++ b/changes/bug-5559_avoid-errors-when-ctrl-c-wizard
@@ -1,0 +1,1 @@
+- Avoid user getting errors if he does a 'ctrl-c' on the wizard during the first run. Closes #5559.

--- a/src/leap/bitmask/gui/mainwindow.py
+++ b/src/leap/bitmask/gui/mainwindow.py
@@ -2046,9 +2046,10 @@ class MainWindow(QtGui.QMainWindow):
 
         # first thing to do quitting, hide the mainwindow and show tooltip.
         self.hide()
-        self._systray.showMessage(
-            self.tr('Quitting...'),
-            self.tr('The app is quitting, please wait.'))
+        if self._systray is not None:
+            self._systray.showMessage(
+                self.tr('Quitting...'),
+                self.tr('The app is quitting, please wait.'))
 
         # explicitly process events to display tooltip immediately
         QtCore.QCoreApplication.processEvents()

--- a/src/leap/bitmask/gui/twisted_main.py
+++ b/src/leap/bitmask/gui/twisted_main.py
@@ -22,9 +22,6 @@ import logging
 from twisted.internet import error, reactor
 from PySide import QtCore
 
-# Resist the temptation of putting the import reactor here,
-# it will raise an "reactor already imported" error.
-
 logger = logging.getLogger(__name__)
 
 
@@ -32,7 +29,11 @@ def stop():
     logger.debug("Really stoping all the things...")
     QtCore.QCoreApplication.sendPostedEvents()
     QtCore.QCoreApplication.flush()
-    reactor.stop()
+    try:
+        reactor.stop()
+        logger.debug('Twisted reactor stopped')
+    except error.ReactorNotRunning:
+        logger.debug('Twisted reactor not running')
     logger.debug("Done stopping all the things.")
 
 
@@ -43,8 +44,4 @@ def quit(app):
     :param app: the main qt QApplication instance.
     :type app: QtCore.QApplication
     """
-    logger.debug('Stopping twisted reactor')
-    try:
-        reactor.callLater(0, stop)
-    except error.ReactorNotRunning:
-        logger.debug('Reactor not running')
+    reactor.callLater(0, stop)


### PR DESCRIPTION
Check that systray exists, not the case during first run.
Cleanup reactor stop code.

Closes #5559.
