### PR TITLE
Update username regex to support the same as webapp.

### DIFF
--- a/changes/bug-5695_fix-username-regex-support
+++ b/changes/bug-5695_fix-username-regex-support
@@ -1,0 +1,3 @@
+- Update username regex to support the same as webapp. Closes #5965.
+- Wrong error message for username too short. (Bug #5697)
+- Cleanup and refactor username/password validators.

--- a/src/leap/bitmask/gui/login.py
+++ b/src/leap/bitmask/gui/login.py
@@ -24,6 +24,7 @@ from ui_login import Ui_LoginWidget
 
 from leap.bitmask.config import flags
 from leap.bitmask.util import make_address
+from leap.bitmask.util.credentials import USERNAME_REGEX
 from leap.bitmask.util.keyring_helpers import has_keyring
 from leap.bitmask.util.keyring_helpers import get_keyring
 from leap.common.check import leap_assert_type
@@ -47,8 +48,6 @@ class LoginWidget(QtGui.QWidget):
     show_wizard = QtCore.Signal()
 
     MAX_STATUS_WIDTH = 40
-
-    BARE_USERNAME_REGEX = r"^[A-Za-z\d_]+$"
 
     # Keyring
     KEYRING_KEY = "bitmask"
@@ -87,7 +86,7 @@ class LoginWidget(QtGui.QWidget):
         self.ui.btnLogout.clicked.connect(
             self.logout)
 
-        username_re = QtCore.QRegExp(self.BARE_USERNAME_REGEX)
+        username_re = QtCore.QRegExp(USERNAME_REGEX)
         self.ui.lnUser.setValidator(
             QtGui.QRegExpValidator(username_re, self))
 

--- a/src/leap/bitmask/gui/preferenceswindow.py
+++ b/src/leap/bitmask/gui/preferenceswindow.py
@@ -27,7 +27,7 @@ from PySide import QtCore, QtGui
 from leap.bitmask.provider import get_provider_path
 from leap.bitmask.config.leapsettings import LeapSettings
 from leap.bitmask.gui.ui_preferences import Ui_Preferences
-from leap.bitmask.util.password import basic_password_checks
+from leap.bitmask.util.credentials import password_checks
 from leap.bitmask.services import get_supported
 from leap.bitmask.config.providerconfig import ProviderConfig
 from leap.bitmask.services import get_service_display_name, MX_SERVICE
@@ -198,7 +198,7 @@ class PreferencesWindow(QtGui.QDialog):
         new_password = self.ui.leNewPassword.text()
         new_password2 = self.ui.leNewPassword2.text()
 
-        ok, msg = basic_password_checks(username, new_password, new_password2)
+        ok, msg = password_checks(username, new_password, new_password2)
 
         if not ok:
             self._set_changing_password(False)

--- a/src/leap/bitmask/util/credentials.py
+++ b/src/leap/bitmask/util/credentials.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# password.py
+# credentials.py
 # Copyright (C) 2013 LEAP
 #
 # This program is free software: you can redistribute it and/or modify
@@ -16,14 +16,34 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """
-Password utilities
+Credentials utilities
 """
-from PySide import QtCore
+from PySide import QtCore, QtGui
 
 WEAK_PASSWORDS = ("123456", "qweasd", "qwerty", "password")
+USERNAME_REGEX = r"^[A-Za-z][A-Za-z\d_\-\.]+[A-Za-z]$"
+
+USERNAME_VALIDATOR = QtGui.QRegExpValidator(QtCore.QRegExp(USERNAME_REGEX))
 
 
-def basic_password_checks(username, password, password2):
+def username_checks(username):
+    # translation helper
+    _tr = QtCore.QObject().tr
+
+    message = None
+
+    if message is None and len(username) < 2:
+        message = _tr("Username must have at least 2 characters")
+
+    valid = USERNAME_VALIDATOR.validate(username, 0)
+    valid_username = valid[0] == QtGui.QValidator.State.Acceptable
+    if message is None and not valid_username:
+        message = _tr("Invalid username")
+
+    return message is None, message
+
+
+def password_checks(username, password, password2):
     """
     Performs basic password checks to avoid really easy passwords.
 
@@ -45,6 +65,9 @@ def basic_password_checks(username, password, password2):
 
     if message is None and password != password2:
         message = _tr("Passwords don't match")
+
+    if message is None and not password:
+        message = _tr("You can't use an empty password")
 
     if message is None and len(password) < 6:
         message = _tr("Password too short")


### PR DESCRIPTION
Rename password util to credentials and add a username check helper.
Move the username regexp to the credentials module.

Closes #5695.
