### PR TITLE
Do nothing if the vpnprocess is not started.

### DIFF
--- a/src/leap/bitmask/backend.py
+++ b/src/leap/bitmask/backend.py
@@ -974,6 +974,7 @@ class Mail(object):
         threads.deferToThread(self._imap_controller.stop_imap_service, cv)
         logger.debug('Waiting for imap service to stop.')
         cv.wait(self.SERVICE_STOP_TIMEOUT)
+        logger.debug('IMAP stopped')
         self._signaler.signal(self._signaler.IMAP_STOPPED)
 
     def stop_imap_service(self):

--- a/src/leap/bitmask/services/eip/vpnprocess.py
+++ b/src/leap/bitmask/services/eip/vpnprocess.py
@@ -317,13 +317,13 @@ class VPN(object):
         from twisted.internet import reactor
         self._stop_pollers()
 
-        # We assume that the only valid stops are initiated
-        # by an user action, not hard restarts
-        self._user_stopped = not restart
-        self._vpnproc.is_restart = restart
-
         # First we try to be polite and send a SIGTERM...
-        if self._vpnproc:
+        if self._vpnproc is not None:
+            # We assume that the only valid stops are initiated
+            # by an user action, not hard restarts
+            self._user_stopped = not restart
+            self._vpnproc.is_restart = restart
+
             self._sentterm = True
             self._vpnproc.terminate_openvpn(shutdown=shutdown)
 


### PR DESCRIPTION
We were trying to access the `is_restart` attribute that causes a
failure if the vpnprocess is not instantiated.
