### PR TITLE
Change password skips soledad if mx is not enabled.

### DIFF
--- a/changes/bug-5540_change-password-fix
+++ b/changes/bug-5540_change-password-fix
@@ -1,0 +1,1 @@
+Change password doesn't work. Closes #5540.

--- a/src/leap/bitmask/gui/mainwindow.py
+++ b/src/leap/bitmask/gui/mainwindow.py
@@ -572,10 +572,13 @@ class MainWindow(QtGui.QMainWindow):
 
         Displays the preferences window.
         """
-        user = self._login_widget.get_user()
-        prov = self._login_widget.get_selected_provider()
-        preferences = PreferencesWindow(
-            self, self._backend, self._soledad_started, user, prov)
+        user = self._logged_user
+        domain = self._login_widget.get_selected_provider()
+        mx_provided = False
+        if self._provider_details is not None:
+            mx_provided = MX_SERVICE in self._provider_details.services
+        preferences = PreferencesWindow(self, user, domain, self._backend,
+                                        self._soledad_started, mx_provided)
 
         self.soledad_ready.connect(preferences.set_soledad_ready)
         preferences.show()


### PR DESCRIPTION
Use information from mainwindow instead of asking again to the backend.
