### PR TITLE
Add support for gnome-shell polkit agent.

### DIFF
--- a/changes/bug-4144_support-gnome-shell-polkit
+++ b/changes/bug-4144_support-gnome-shell-polkit
@@ -1,0 +1,1 @@
+- Add support for gnome-shell polkit agent. Closes #4144, #4218.

--- a/src/leap/bitmask/services/eip/linuxvpnlauncher.py
+++ b/src/leap/bitmask/services/eip/linuxvpnlauncher.py
@@ -71,7 +71,20 @@ def _is_auth_agent_running():
         'ps aux | grep "[l]xpolkit"'
     ]
     is_running = [commands.getoutput(cmd) for cmd in polkit_options]
-    return any(is_running)
+
+    # gnome-shell does not uses a separate process for the polkit-agent, it
+    # uses a polkit-agent within its own process so we can't ps-grep it.
+    is_running = any(is_running)
+    if not is_running:
+        is_gnome_shell = commands.getoutput('ps aux | grep [g]nome-shell')
+
+        # $DESKTOP_SESSION == 'gnome' -> gnome-shell
+        # $DESKTOP_SESSION == 'gnome-fallback' -> gnome-shell fallback mode,
+        # uses polkit-gnome...
+        if is_gnome_shell and os.getenv("DESKTOP_SESSION") == 'gnome':
+            is_running = True
+
+    return is_running
 
 
 def _try_to_launch_agent():


### PR DESCRIPTION
The gnome-shell desktop does not uses a separate process as others do.
It uses an agent within its own process so we need to check for
gnome-shell and then assume that its polkit is working.
