### PR TITLE
Grep for gnome-shell as it were a polkit agent.

### DIFF
--- a/src/leap/bitmask/services/eip/linuxvpnlauncher.py
+++ b/src/leap/bitmask/services/eip/linuxvpnlauncher.py
@@ -63,28 +63,21 @@ def _is_auth_agent_running():
     :return: True if it's running, False if it's not.
     :rtype: boolean
     """
+    # Note that gnome-shell does not uses a separate process for the
+    # polkit-agent, it uses a polkit-agent within its own process so we can't
+    # ps-grep a polkit process, we can ps-grep gnome-shell itself.
+
     # the [x] thing is to avoid grep match itself
     polkit_options = [
         'ps aux | grep "polkit-[g]nome-authentication-agent-1"',
         'ps aux | grep "polkit-[k]de-authentication-agent-1"',
         'ps aux | grep "polkit-[m]ate-authentication-agent-1"',
-        'ps aux | grep "[l]xpolkit"'
+        'ps aux | grep "[l]xpolkit"',
+        'ps aux | grep "[g]nome-shell"',
     ]
     is_running = [commands.getoutput(cmd) for cmd in polkit_options]
 
-    # gnome-shell does not uses a separate process for the polkit-agent, it
-    # uses a polkit-agent within its own process so we can't ps-grep it.
-    is_running = any(is_running)
-    if not is_running:
-        is_gnome_shell = commands.getoutput('ps aux | grep [g]nome-shell')
-
-        # $DESKTOP_SESSION == 'gnome' -> gnome-shell
-        # $DESKTOP_SESSION == 'gnome-fallback' -> gnome-shell fallback mode,
-        # uses polkit-gnome...
-        if is_gnome_shell and os.getenv("DESKTOP_SESSION") == 'gnome':
-            is_running = True
-
-    return is_running
+    return any(is_running)
 
 
 def _try_to_launch_agent():


### PR DESCRIPTION
The $DESKTOP_SESSION is not reliable since is set to 'default' in any
case that you choose as your default desktop environment.

Also, after some tests, I've seen that the `gnome-shell` process is not
launched in the fallback mode, so we use it as a condition for the
polkit agent present.
