### PR TITLE
do reinstall binaries if their hash is not the expected

### DIFF
--- a/changes/feature_update-bundle-binaries
+++ b/changes/feature_update-bundle-binaries
@@ -1,0 +1,1 @@
+- Update the bundled binaries to their path if their sha256 is not correct. Closes:#5759


### PR DESCRIPTION
Closes: #5759

For this to work, the bundle needs to call::
`python setup.py hash_binaries` during the bundling process, so that
the right hash gets updated in the bitmask/_binaries.py file.
