### PR TITLE
Disable user/pass remembering temporarily.

### DIFF
--- a/changes/disable-user-pass-remembering
+++ b/changes/disable-user-pass-remembering
@@ -1,0 +1,1 @@
+- Temporarily disable username/password remembering to avoid keyring issues. Related to #4190.

--- a/src/leap/bitmask/gui/login.py
+++ b/src/leap/bitmask/gui/login.py
@@ -216,7 +216,8 @@ class LoginWidget(QtGui.QWidget):
         """
         self.ui.lnUser.setEnabled(enabled)
         self.ui.lnPassword.setEnabled(enabled)
-        self.ui.chkRemember.setEnabled(enabled)
+        if has_keyring():
+            self.ui.chkRemember.setEnabled(enabled)
         self.ui.cmbProviders.setEnabled(enabled)
 
         self._set_cancel(not enabled)

--- a/src/leap/bitmask/util/keyring_helpers.py
+++ b/src/leap/bitmask/util/keyring_helpers.py
@@ -34,6 +34,10 @@ except Exception:
     # dbus socket, or stuff like that.
     keyring = None
 
+# XXX remember password disabled right now!
+# see: https://leap.se/code/issues/4190
+keyring = None
+
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +50,7 @@ def _get_keyring_with_fallback():
     This is a workaround for the cases in which the keyring module chooses
     an insecure keyring by default (ie, inside a virtualenv).
     """
-    if not keyring:
+    if keyring is None:
         return None
     kr = keyring.get_keyring()
     if not canuse(kr):
@@ -67,7 +71,7 @@ def has_keyring():
 
     :rtype: bool
     """
-    if not keyring:
+    if keyring is None:
         return False
     kr = _get_keyring_with_fallback()
     return canuse(kr)
@@ -79,7 +83,7 @@ def get_keyring():
 
     :rtype: keyringBackend or None
     """
-    if not keyring:
+    if keyring is None:
         return False
     kr = _get_keyring_with_fallback()
     return kr if canuse(kr) else None


### PR DESCRIPTION
Set the keyring to None in order to simulate an always unavailable
keyring, that way we avoid the possibility of the user running into the
existing keyring issues. See https://leap.se/code/issues/4190

Update comparisons to do a proper comparison with `None`.
Fix login widget 'enabled' changer in order to change the 'remember'
widget _only_ if we have an usable keyring.
