### PR TITLE
Do `quit()` if the system requested the app to close.

### DIFF
--- a/changes/5870_bitmask-prevent-system-logout-on-linux
+++ b/changes/5870_bitmask-prevent-system-logout-on-linux
@@ -1,0 +1,1 @@
+- Bitmask on linux prevents session logout. Closes #5870.

--- a/src/leap/bitmask/gui/mainwindow.py
+++ b/src/leap/bitmask/gui/mainwindow.py
@@ -1138,6 +1138,11 @@ class MainWindow(QtGui.QMainWindow):
         """
         Reimplementation of closeEvent to close to tray
         """
+        if not e.spontaneous():
+            # if the system requested the `close` then we should quit.
+            self.quit()
+            return
+
         if QtGui.QSystemTrayIcon.isSystemTrayAvailable() and \
                 not self._really_quit:
             self._toggle_visible()


### PR DESCRIPTION
This fixes the issue where a system logout was blocked by bitmask since
we were interpreting the closeEvent as if the user clicked on the 'X'
button.
Closes #5870.
