### PR TITLE
Fix logger window blocking the bitmask quit().

### DIFF
--- a/changes/bug_logger-hangs-quit
+++ b/changes/bug_logger-hangs-quit
@@ -1,0 +1,1 @@
+- Fix logger window blocking the bitmask quit().

--- a/src/leap/bitmask/gui/loggerwindow.py
+++ b/src/leap/bitmask/gui/loggerwindow.py
@@ -40,14 +40,14 @@ class LoggerWindow(QtGui.QDialog):
     _paste_ok = QtCore.Signal(object)
     _paste_error = QtCore.Signal(object)
 
-    def __init__(self, handler):
+    def __init__(self, parent, handler):
         """
         Initialize the widget with the custom handler.
 
         :param handler: Custom handler that supports history and signal.
         :type handler: LeapLogHandler.
         """
-        QtGui.QDialog.__init__(self)
+        QtGui.QDialog.__init__(self, parent)
         leap_assert(handler, "We need a handler for the logger window")
         leap_assert_type(handler, LeapLogHandler)
 

--- a/src/leap/bitmask/gui/mainwindow.py
+++ b/src/leap/bitmask/gui/mainwindow.py
@@ -277,8 +277,6 @@ class MainWindow(QtGui.QMainWindow):
         self._wizard = None
         self._wizard_firstrun = False
 
-        self._logger_window = None
-
         self._start_hidden = start_hidden
         self._backend_pid = backend_pid
 
@@ -568,17 +566,13 @@ class MainWindow(QtGui.QMainWindow):
         Display the window with the history of messages logged until now
         and displays the new ones on arrival.
         """
-        if self._logger_window is None:
-            leap_log_handler = self._get_leap_logging_handler()
-            if leap_log_handler is None:
-                logger.error('Leap logger handler not found')
-                return
-            else:
-                self._logger_window = LoggerWindow(handler=leap_log_handler)
-                self._logger_window.setVisible(
-                    not self._logger_window.isVisible())
+        leap_log_handler = self._get_leap_logging_handler()
+        if leap_log_handler is None:
+            logger.error('Leap logger handler not found')
+            return
         else:
-            self._logger_window.setVisible(not self._logger_window.isVisible())
+            lw = LoggerWindow(self, handler=leap_log_handler)
+            lw.show()
 
     @QtCore.Slot()
     def _show_AKM(self):
@@ -1836,9 +1830,6 @@ class MainWindow(QtGui.QMainWindow):
         # Close other windows if any.
         if self._wizard:
             self._wizard.close()
-
-        if self._logger_window is not None:
-            self._logger_window.close()
 
         # Set this in case that the app is hidden
         QtGui.QApplication.setQuitOnLastWindowClosed(True)


### PR DESCRIPTION
- Set the logger window parent,
- don't use an mainwindow instance variable to hold the window object.

This fix have the side offect that prevent multiple log windows being
created at the same time, but it does not causes any side effect or
problem.
