### PR TITLE
more specific library dependencies

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-bitmask (0.6.1~rc2) unstable; urgency=medium
+bitmask (0.6.1~rc3) unstable; urgency=medium
 
   * Update to 0.6.1 release
 

--- a/debian/control
+++ b/debian/control
@@ -33,9 +33,10 @@ Depends:
   python-jsonschema (>= 0.7.0),
   python-setuptools,
   openvpn,
-  python-pyside, 
   python-pyside.qtcore, 
   python-pyside.qtgui,
+  python-pyside.qtsvg,
+  python-twisted-core,
   python-leap-common,
   leap-mail,
   soledad-client

--- a/pkg/requirements.pip
+++ b/pkg/requirements.pip
@@ -14,7 +14,7 @@ python-dateutil
 psutil
 
 ipaddr
-twisted
+#twisted   # removed for debian package
 python-daemon # this should not be needed for Windows.
 keyring
 zope.proxy


### PR DESCRIPTION
use more specific sub-packages for pyside and twisted, we don't need the whole thing
