### PR TITLE
Select current provider on EIP preferences.

### DIFF
--- a/changes/bug-5815_eip-preferences-issues
+++ b/changes/bug-5815_eip-preferences-issues
@@ -1,0 +1,2 @@
+- Select current provider on EIP preferences. Closes #5815.
+- Handle logout correctly when we stop_services to launch the wizard. Related to #5815.

--- a/src/leap/bitmask/gui/eip_preferenceswindow.py
+++ b/src/leap/bitmask/gui/eip_preferenceswindow.py
@@ -116,11 +116,14 @@ class EIPPreferencesWindow(QtGui.QDialog):
             self.ui.gbGatewaySelector.setEnabled(False)
             return
 
+        # block signals so the currentIndexChanged slot doesn't get triggered
+        self.ui.cbProvidersGateway.blockSignals(True)
         for provider, is_initialized in providers:
             label = provider
             if not is_initialized:
                 label += self.tr(" (uninitialized)")
             self.ui.cbProvidersGateway.addItem(label, userData=provider)
+        self.ui.cbProvidersGateway.blockSignals(False)
 
         # Select provider by name
         domain = self._selected_domain

--- a/src/leap/bitmask/gui/mainwindow.py
+++ b/src/leap/bitmask/gui/mainwindow.py
@@ -413,11 +413,6 @@ class MainWindow(QtGui.QMainWindow):
             "Invalid username or password."))
         conntrack(sig.srp_auth_bad_user_or_password, auth_bad_user_or_password)
 
-        # Logout signals
-        conntrack(sig.srp_logout_ok, self._logout_ok)
-        conntrack(sig.srp_logout_error, self._logout_error)
-        conntrack(sig.srp_not_logged_in_error, self._not_logged_in_error)
-
         # EIP bootstrap signals
         conntrack(sig.eip_config_ready, self._eip_intermediate_stage)
         conntrack(sig.eip_client_certificate_ready, self._finish_eip_bootstrap)
@@ -436,8 +431,12 @@ class MainWindow(QtGui.QMainWindow):
         sig.prov_unsupported_api.connect(self._incompatible_api)
         sig.prov_get_all_services.connect(self._provider_get_all_services)
 
-        # EIP start signals ==============================================
+        # Logout signals =================================================
+        sig.srp_logout_ok.connect(self._logout_ok)
+        sig.srp_logout_error.connect(self._logout_error)
+        sig.srp_not_logged_in_error.connect(self._not_logged_in_error)
 
+        # EIP start signals ==============================================
         self._eip_conductor.connect_backend_signals()
         sig.eip_can_start.connect(self._backend_can_start_eip)
         sig.eip_cannot_start.connect(self._backend_cannot_start_eip)

--- a/src/leap/bitmask/gui/providers.py
+++ b/src/leap/bitmask/gui/providers.py
@@ -109,6 +109,6 @@ class Providers(QtCore.QObject):
         """
         self._providers_indexes.append(idx)
         is_wizard = idx == (self._combo.count() - 1)
-        self._provider_changed.emit(is_wizard)
         if is_wizard:
             self.restore_previous_provider()
+        self._provider_changed.emit(is_wizard)


### PR DESCRIPTION
- Don't disconnect logout signals, so when the wizard is triggered the
  UI can reflect the logout result.
- Restore the selected provider when 'other...' is selected _before_ the
  provider_changed signal is emitted to avoid that option to keep
  selected in case of some error.
- Avoid the currentIndexChanged to be triggered when we load the providers.
