### PR TITLE
Hide button / improve message on missing helpers.

### DIFF
--- a/changes/bug-5945_not-adding-helper-files
+++ b/changes/bug-5945_not-adding-helper-files
@@ -1,0 +1,1 @@
+- Hide button and display correct warning on missing helpers files. Closes #5945.

--- a/src/leap/bitmask/gui/eip_status.py
+++ b/src/leap/bitmask/gui/eip_status.py
@@ -303,7 +303,6 @@ class EIPStatusWidget(QtGui.QWidget):
         """
         # XXX this name is unfortunate. "disable" is also applied to a
         # pushbutton being grayed out.
-
         logger.debug('Hiding EIP start button')
         # you might be tempted to change this for a .setEnabled(False).
         # it won't work. it's under the claws of the state machine.
@@ -334,7 +333,7 @@ class EIPStatusWidget(QtGui.QWidget):
         Triggered after a successful login.
         Enables the start button.
         """
-        # logger.debug('Showing EIP start button')
+        logger.debug('Showing EIP start button')
         self.eip_button.show()
         self.hide_eip_cancel_button()
 

--- a/src/leap/bitmask/gui/mainwindow.py
+++ b/src/leap/bitmask/gui/mainwindow.py
@@ -656,6 +656,10 @@ class MainWindow(QtGui.QMainWindow):
         to do so, start it. Otherwise it leaves everything in place
         for the user to click Turn ON.
         """
+        if self._eip_status.missing_helpers:
+            self._eip_status.disable_eip_start()
+            return
+
         settings = self._settings
         default_provider = settings.get_defaultprovider()
         enabled_services = []
@@ -700,7 +704,9 @@ class MainWindow(QtGui.QMainWindow):
             self._eip_status.disable_eip_start()
         else:
             self._eip_status.disable_eip_start()
-            self._eip_status.set_eip_status(self.tr("Disabled"))
+            # NOTE: we shouldn't be setting the message here.
+            if not self._eip_status.missing_helpers:
+                self._eip_status.set_eip_status(self.tr("Disabled"))
 
         # this state flag is responsible for deferring the login
         # so we must update it, otherwise we're in a deadlock.
@@ -812,6 +818,15 @@ class MainWindow(QtGui.QMainWindow):
 
         self._show_hide_unsupported_services()
 
+        # XXX - HACK, kind of...
+        # With the 1ms QTimer.singleShot call we schedule the call right after
+        # other signals waiting for the qt reactor to take control.
+        # That way, the method is called right after the EIP machines' signals.
+        # We need to wait until that happens because the state-machine
+        # controlled widget shows the 'Turn On' button and we want to do the
+        # changes to that button right after, not before.
+        QtDelayedCall(1, self._update_eip_enabled_status)
+
         if self._wizard:
             possible_username = self._wizard.get_username()
             possible_password = self._wizard.get_password()
@@ -836,8 +851,6 @@ class MainWindow(QtGui.QMainWindow):
             self._wizard = None
             self._backend_connect(only_tracked=True)
         else:
-            self._update_eip_enabled_status()
-
             domain = self._settings.get_provider()
             if domain is not None:
                 self._providers.select_provider_by_name(domain)

--- a/src/leap/bitmask/platform_init/initializers.py
+++ b/src/leap/bitmask/platform_init/initializers.py
@@ -164,12 +164,19 @@ def check_missing():
             logger.debug(
                 "Setting alert_missing_scripts to False, we will not "
                 "ask again")
+            init_signals.eip_missing_helpers.emit()
             config.set_alert_missing_scripts(False)
 
     if complain_missing and missing_some:
         missing = missing_scripts() + missing_other()
         msg = _get_missing_complain_dialog(missing)
         ret = msg.exec_()
+
+    # If there is some missing file and we don't want to complain, we emit the
+    # 'missing helpers' signal so the eip status can show that some files are
+    # missing.
+    if missing_some and not alert_missing and not complain_missing:
+        init_signals.eip_missing_helpers.emit()
 
 #
 # windows initializers


### PR DESCRIPTION
- Emit the `eip_missing_helpers` signal when the user chooses "Don't ask
  me again".
- We emit that signal when some helper file is missing, even if the user
  doesn't want a warning.
- Do the update of the eip enabled status with some delay to give some
  time the eip machine to start and do what it needs with the
  buttons/labels and avoid the 'hide turn on button if missing files'
  being overridden.

Closes #5945.
