### PR TITLE
Removed hard coded path of python app on mac platform

### DIFF
--- a/pkg/postmkvenv.sh
+++ b/pkg/postmkvenv.sh
@@ -27,7 +27,13 @@ LIB_VIRTUALENV_PATH=$(python -c "$GET_PYTHON_LIB_CMD")
 if [[ $platform == 'linux' ]]; then
     LIB_SYSTEM_PATH=$(${VAR[-1]} -c "$GET_PYTHON_LIB_CMD")
 elif [[ $platform == 'darwin' ]]; then
+    ORIGINAL_PATH=$PATH
+    #change first colon of path to | because path substitution is greedy
+    PATH=${PATH/:/|}
+    #remove everything up to | from path
+    PATH=${PATH/*|/}
     LIB_SYSTEM_PATH=$(python -c "$GET_PYTHON_LIB_CMD")
+    PATH=$ORIGINAL_PATH
 else
     echo "unsupported platform; not doing symlinks"
 fi


### PR DESCRIPTION
I am trying to make the **./bootstrap_develop.sh** work on mac, one of the problems I've had is that the bitmask_client **postmkvenv.sh** is trying to use a hardcoded python (with the path used by macports) to get the python lib.

Most people I know use homebrew instead and that would be yet another path, so I think the best way to go is using the python directly (considering mac comes with python installed since forever).
