### PR TITLE
Use python2 explicitly to run bitmask-root.

### DIFF
--- a/changes/bug-6048_python2-bitmask-root
+++ b/changes/bug-6048_python2-bitmask-root
@@ -1,0 +1,1 @@
+- Use python2 to run bitmask-root to work fine on systems with python3 as default. Closes #6048.

--- a/pkg/linux/bitmask-root
+++ b/pkg/linux/bitmask-root
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2014 LEAP


### PR DESCRIPTION
Closes #6048.
