### PR TITLE
Improve support for RTL languages.

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[bitmask.bitmask]
+[bitmask.bitmask_client]
 
 file_filter = data/translations/<lang>.ts
 source_file = data/ts/en_US.ts

--- a/src/leap/bitmask/frontend_app.py
+++ b/src/leap/bitmask/frontend_app.py
@@ -76,15 +76,24 @@ def run_frontend(options, flags_dict, backend_pid):
 
     qApp = QtGui.QApplication(sys.argv)
 
-    # To test:
-    # $ LANG=es ./app.py
-    locale = QtCore.QLocale.system().name()
-    qtTranslator = QtCore.QTranslator()
-    if qtTranslator.load("qt_%s" % locale, ":/translations"):
-        qApp.installTranslator(qtTranslator)
-    appTranslator = QtCore.QTranslator()
-    if appTranslator.load("%s.qm" % locale[:2], ":/translations"):
-        qApp.installTranslator(appTranslator)
+    # To test the app in other language you can do:
+    #     shell> LANG=es bitmask
+    # or in some rare case if the code above didn't work:
+    #     shell> LC_ALL=es LANG=es bitmask
+    locale = QtCore.QLocale.system().name()  # en_US, es_AR, ar_SA, etc
+    locale_short = locale[:2]  # en, es, ar, etc
+    rtl_languages = ('ar', )  # right now tested on 'arabic' only.
+
+    systemQtTranslator = QtCore.QTranslator()
+    if systemQtTranslator.load("qt_%s" % locale, ":/translations"):
+        qApp.installTranslator(systemQtTranslator)
+
+    bitmaskQtTranslator = QtCore.QTranslator()
+    if bitmaskQtTranslator.load("%s.qm" % locale_short, ":/translations"):
+        qApp.installTranslator(bitmaskQtTranslator)
+
+    if locale_short in rtl_languages:
+        qApp.setLayoutDirection(QtCore.Qt.LayoutDirection.RightToLeft)
 
     # Needed for initializing qsettings it will write
     # .config/leap/leap.conf top level app settings in a platform

--- a/src/leap/bitmask/gui/eip_status.py
+++ b/src/leap/bitmask/gui/eip_status.py
@@ -97,7 +97,7 @@ class EIPStatusWidget(QtGui.QWidget):
 
         # Action for the systray
         self._eip_disabled_action = QtGui.QAction(
-            "{0} is {1}".format(self._service_name, self.tr("disabled")), self)
+            u"{0} is {1}".format(self._service_name, self.tr("disabled")), self)
 
     def connect_backend_signals(self):
         """

--- a/src/leap/bitmask/gui/mainwindow.py
+++ b/src/leap/bitmask/gui/mainwindow.py
@@ -934,7 +934,7 @@ class MainWindow(QtGui.QMainWindow):
         systrayMenu.addAction(self._action_visible)
         systrayMenu.addSeparator()
 
-        eip_status_label = "{0}: {1}".format(
+        eip_status_label = u"{0}: {1}".format(
             self._eip_conductor.eip_name, self.tr("OFF"))
         self._eip_menu = eip_menu = systrayMenu.addMenu(eip_status_label)
         eip_menu.addAction(self._action_eip_startstop)


### PR DESCRIPTION
- Update transifex resource name.
- Use RightToLeft layout for Arabic language.
- Use better names and comments on i18n section.
- Use unicode to initialize widgets with text that otherwise (str) will
  fail when Arabic (and most likely any other language with non-ascii
  characters) is used.

Closes #5289, #6033.
