### PR TITLE
Hide AKM menu and disable the qt connection.

### DIFF
--- a/changes/feature-6087_remove-AKM-menu
+++ b/changes/feature-6087_remove-AKM-menu
@@ -1,0 +1,2 @@
+- Remove the Advanced Key Management since we don't support stable mail yet.
+  Closes #6087.

--- a/src/leap/bitmask/gui/mainwindow.py
+++ b/src/leap/bitmask/gui/mainwindow.py
@@ -224,8 +224,9 @@ class MainWindow(QtGui.QMainWindow):
         self.ui.action_create_new_account.triggered.connect(
             self._on_provider_changed)
 
-        self.ui.action_advanced_key_management.triggered.connect(
-            self._show_AKM)
+        # Action item hidden since we don't provide stable mail yet.
+        # self.ui.action_advanced_key_management.triggered.connect(
+        #     self._show_AKM)
 
         if IS_MAC:
             self.ui.menuFile.menuAction().setText(self.tr("File"))

--- a/src/leap/bitmask/gui/ui/mainwindow.ui
+++ b/src/leap/bitmask/gui/ui/mainwindow.ui
@@ -75,7 +75,7 @@
          <x>0</x>
          <y>0</y>
          <width>524</width>
-         <height>540</height>
+         <height>549</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout">
@@ -306,7 +306,7 @@
      <x>0</x>
      <y>0</y>
      <width>524</width>
-     <height>25</height>
+     <height>21</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -378,10 +378,13 @@
   </action>
   <action name="action_advanced_key_management">
    <property name="enabled">
-    <bool>true</bool>
+    <bool>false</bool>
    </property>
    <property name="text">
     <string>Advanced Key Management</string>
+   </property>
+   <property name="visible">
+    <bool>false</bool>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Hide the Advaneced Key Management menu from the ui file and comment out
the connection between the triggered action and the method that shows
the AKM window.

Closes #6087.
