### PR TITLE
Use python2.7 instead of python2.

### DIFF
--- a/changes/bug_python2-compat
+++ b/changes/bug_python2-compat
@@ -1,0 +1,1 @@
+- Use python2.7 since is the common name for python 2 in Ubuntu, Debian, Arch. Related to #6048.

--- a/pkg/linux/bitmask-root
+++ b/pkg/linux/bitmask-root
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python2.7
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2014 LEAP


### PR DESCRIPTION
The binary `python2` is not present on Debian systems.
The common denominator for Ubuntu, Debian, Arch is `python2.7`

Related to #6048.
