### PR TITLE
Pin/unpin dependencies.

### DIFF
--- a/pkg/requirements.pip
+++ b/pkg/requirements.pip
@@ -10,15 +10,14 @@ requests>=1.1.0
 srp>=1.0.2
 pyopenssl
 
-# This won't be needed after we refactor leap.common.events
-# to use zmq.
-python-dateutil==1.4  # See  https://leap.se/code/issues/6099
+# This won't be needed after we refactor leap.common.events to use zmq.
+python-dateutil
 
 psutil
 
 ipaddr
 twisted
-python-daemon # this should not be needed for Windows.
+python-daemon==1.6.1 # this should not be needed for Windows.
 keyring
 zope.proxy
 


### PR DESCRIPTION
Unpin python-dateutil since is no longer a problem.
Pin python-daemon since latest version (2.0.3 as today) fails to get
installed wich causes problems with the bundle and the bootstrapper
script.