### PR TITLE
Fix failing tests.

### DIFF
--- a/src/leap/bitmask/config/tests/test_providerconfig.py
+++ b/src/leap/bitmask/config/tests/test_providerconfig.py
@@ -258,18 +258,6 @@ class ProviderConfigTest(BaseLeapTest):
         pc.load(data=json_string)
         self.assertTrue('unknown' in pc.get_services())
 
-    def test_get_services_string(self):
-        pc = self._provider_config
-        config = copy.deepcopy(sample_config)
-        config['services'] = [
-            'openvpn', 'asdf', 'openvpn', 'not_supported_service']
-        json_string = json.dumps(config)
-        pc.load(data=json_string)
-
-        self.assertEqual(pc.get_services_string(),
-                         "Encrypted Internet, asdf, Encrypted Internet,"
-                         " not_supported_service")
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/leap/bitmask/provider/tests/test_providerbootstrapper.py
+++ b/src/leap/bitmask/provider/tests/test_providerbootstrapper.py
@@ -38,7 +38,6 @@ from requests.models import Response
 
 from leap.bitmask import provider
 from leap.bitmask import util
-from leap.bitmask.backend import Signaler
 from leap.bitmask.config.providerconfig import ProviderConfig
 from leap.bitmask.crypto.tests import fake_provider
 from leap.bitmask.provider.providerbootstrapper import ProviderBootstrapper
@@ -51,7 +50,7 @@ from leap.common.testing.https_server import where
 
 class ProviderBootstrapperTest(BaseLeapTest):
     def setUp(self):
-        self.pb = ProviderBootstrapper(Signaler())
+        self.pb = ProviderBootstrapper()
 
     def tearDown(self):
         pass

--- a/src/leap/bitmask/services/eip/eipbootstrapper.py
+++ b/src/leap/bitmask/services/eip/eipbootstrapper.py
@@ -115,10 +115,15 @@ class EIPBootstrapper(AbstractBootstrapper):
         self._provider_config = provider_config
         self._download_if_needed = download_if_needed
 
+        eip_config_ready = None
+        eip_certificate_ready = None
+        if self._signaler is not None:
+            eip_config_ready = self._signaler.eip_config_ready
+            eip_certificate_ready = self._signaler.eip_client_certificate_ready
+
         cb_chain = [
-            (self._download_config, self._signaler.eip_config_ready),
-            (self._download_client_certificates,
-             self._signaler.eip_client_certificate_ready)
+            (self._download_config, eip_config_ready),
+            (self._download_client_certificates, eip_certificate_ready)
         ]
 
         return self.addCallbackChain(cb_chain)

--- a/src/leap/bitmask/services/eip/eipconfig.py
+++ b/src/leap/bitmask/services/eip/eipconfig.py
@@ -118,6 +118,8 @@ class VPNGatewaySelector(object):
         """
         gateways_timezones = []
         locations = self._eipconfig.get_locations()
+        if not locations:
+            locations = {}
         gateways = self._eipconfig.get_gateways()
 
         for idx, gateway in enumerate(gateways):


### PR DESCRIPTION
Remove srpauth obsolete tests.
Remove providerconfig obsolete test.
Set as mandatory the signaler object on ProviderBootstrapper and
EIPBootstrapper.

Closes #6631.