### PR TITLE
Use different config path for bitmask.

### DIFF
--- a/src/leap/bitmask/app.py
+++ b/src/leap/bitmask/app.py
@@ -54,6 +54,7 @@ from leap.bitmask.logs.utils import create_logger
 from leap.bitmask.platform_init.locks import we_are_the_one_and_only
 from leap.bitmask.services.mail import plumber
 from leap.bitmask.util import leap_argparse, flags_to_dict
+from leap.bitmask.util import _move_config_leap_to_bitmask
 from leap.bitmask.util.requirement_checker import check_requirements
 
 from leap.common.events import server as event_server
@@ -145,6 +146,18 @@ def start_app():
         replace_stdout = False
 
     logger = create_logger(opts.debug, opts.log_file, replace_stdout)
+
+    try:
+        migration = _move_config_leap_to_bitmask()
+        if migration:
+            logger.debug("We successfully migrated your config path to its "
+                         "new name.")
+        else:
+            logger.debug("Config path name migration not needed.")
+
+    except IOError as e:
+        logger.error(e)
+        return
 
     # ok, we got logging in place, we can satisfy mail plumbing requests
     # and show logs there. it normally will exit there if we got that path.

--- a/src/leap/bitmask/backend/settings.py
+++ b/src/leap/bitmask/backend/settings.py
@@ -21,7 +21,7 @@ import ConfigParser
 import logging
 import os
 
-from leap.bitmask.util import get_path_prefix
+from leap.bitmask.util import get_bitmask_config_path
 from leap.common.check import leap_assert, leap_assert_type
 
 logger = logging.getLogger(__name__)
@@ -44,8 +44,8 @@ class Settings(object):
         """
         Create the ConfigParser object and read it.
         """
-        self._settings_path = os.path.join(get_path_prefix(),
-                                           "leap", self.CONFIG_NAME)
+        self._settings_path = os.path.join(get_bitmask_config_path(),
+                                           self.CONFIG_NAME)
 
         self._settings = ConfigParser.ConfigParser()
         self._settings.read(self._settings_path)

--- a/src/leap/bitmask/backend/utils.py
+++ b/src/leap/bitmask/backend/utils.py
@@ -24,12 +24,12 @@ import stat
 
 import zmq.auth
 
-from leap.bitmask.util import get_path_prefix
+from leap.bitmask.util import get_bitmask_config_path
 from leap.common.files import mkdir_p
 
 logger = logging.getLogger(__name__)
 
-KEYS_DIR = os.path.join(get_path_prefix(), 'leap', 'zmq_certificates')
+KEYS_DIR = os.path.join(get_bitmask_config_path(), 'zmq_certificates')
 
 
 def generate_zmq_certificates():

--- a/src/leap/bitmask/config/leapsettings.py
+++ b/src/leap/bitmask/config/leapsettings.py
@@ -23,7 +23,7 @@ import logging
 from PySide import QtCore
 
 from leap.common.check import leap_assert, leap_assert_type
-from leap.bitmask.util import get_path_prefix
+from leap.bitmask.util import get_bitmask_config_path
 
 logger = logging.getLogger(__name__)
 
@@ -75,8 +75,8 @@ class LeapSettings(object):
     GATEWAY_AUTOMATIC = "Automatic"
 
     def __init__(self):
-        settings_path = os.path.join(get_path_prefix(),
-                                     "leap", self.CONFIG_NAME)
+        settings_path = os.path.join(get_bitmask_config_path(),
+                                     self.CONFIG_NAME)
 
         self._settings = QtCore.QSettings(settings_path,
                                           QtCore.QSettings.IniFormat)
@@ -128,8 +128,8 @@ class LeapSettings(object):
         # other things, not just the directories
         providers = []
         try:
-            providers_path = os.path.join(get_path_prefix(),
-                                          "leap", "providers")
+            providers_path = os.path.join(get_bitmask_config_path(),
+                                          "providers")
             providers = os.listdir(providers_path)
         except Exception as e:
             logger.debug("Error listing providers, assume there are none. %r"

--- a/src/leap/bitmask/config/providerconfig.py
+++ b/src/leap/bitmask/config/providerconfig.py
@@ -25,7 +25,7 @@ from leap.bitmask import provider
 from leap.bitmask.config import flags
 from leap.bitmask.config.provider_spec import leap_provider_spec
 from leap.bitmask.services import get_service_display_name
-from leap.bitmask.util import get_path_prefix
+from leap.bitmask.util import get_bitmask_config_path
 from leap.common.check import leap_check
 from leap.common.config.baseconfig import BaseConfig, LocalizedKey
 
@@ -192,7 +192,7 @@ class ProviderConfig(BaseConfig):
         :rtype: unicode
         """
 
-        cert_path = os.path.join(get_path_prefix(), "leap", "providers",
+        cert_path = os.path.join(get_bitmask_config_path(), "providers",
                                  self.get_domain(), "keys", "ca", "cacert.pem")
 
         if not about_to_download:

--- a/src/leap/bitmask/config/tests/test_providerconfig.py
+++ b/src/leap/bitmask/config/tests/test_providerconfig.py
@@ -177,7 +177,7 @@ class ProviderConfigTest(BaseLeapTest):
         pc = self._provider_config
 
         provider_domain = sample_config['domain']
-        expected_path = os.path.join('leap', 'providers',
+        expected_path = os.path.join('bitmask', 'providers',
                                      provider_domain, 'keys', 'ca',
                                      'cacert.pem')
 
@@ -191,7 +191,7 @@ class ProviderConfigTest(BaseLeapTest):
         pc = self._provider_config
 
         provider_domain = sample_config['domain']
-        expected_path = os.path.join('leap', 'providers',
+        expected_path = os.path.join('bitmask', 'providers',
                                      provider_domain, 'keys', 'ca',
                                      'cacert.pem')
 

--- a/src/leap/bitmask/crypto/tests/test_srpauth.py
+++ b/src/leap/bitmask/crypto/tests/test_srpauth.py
@@ -122,7 +122,7 @@ class SRPAuthTestCase(unittest.TestCase):
 
         # HACK: this is needed since it seems that the backend settings path is
         # not using the right path
-        mkdir_p('config/leap')
+        mkdir_p('config/bitmask')
 
     def tearDown(self):
         self.auth_backend._session.post = self.old_post

--- a/src/leap/bitmask/logs/log_silencer.py
+++ b/src/leap/bitmask/logs/log_silencer.py
@@ -21,7 +21,7 @@ import logging
 import os
 import re
 
-from leap.bitmask.util import get_path_prefix
+from leap.bitmask.util import get_bitmask_config_path
 
 
 class SelectiveSilencerFilter(logging.Filter):
@@ -29,7 +29,7 @@ class SelectiveSilencerFilter(logging.Filter):
     Configurable filter for root leap logger.
 
     If you want to ignore components from the logging, just add them,
-    one by line, to ~/.config/leap/leap.dev.conf
+    one by line, to the file 'get_bitmask_config_path()' + '/leap.dev.conf'
     """
     # TODO we can augment this by properly parsing the log-silencer file
     # and having different sections: ignore, levels, ...
@@ -65,7 +65,7 @@ class SelectiveSilencerFilter(logging.Filter):
         """
         The configuration file for custom ignore rules.
         """
-        return os.path.join(get_path_prefix(), "leap", self.CONFIG_NAME)
+        return os.path.join(get_bitmask_config_path(), self.CONFIG_NAME)
 
     def _load_rules(self):
         """

--- a/src/leap/bitmask/provider/__init__.py
+++ b/src/leap/bitmask/provider/__init__.py
@@ -39,7 +39,7 @@ def get_provider_path(domain):
     :rtype: str
     """
     leap_assert(domain is not None, "get_provider_path: We need a domain")
-    return os.path.join("leap", "providers", domain, "provider.json")
+    return os.path.join("bitmask", "providers", domain, "provider.json")
 
 
 def supports_api(api_version):

--- a/src/leap/bitmask/provider/providerbootstrapper.py
+++ b/src/leap/bitmask/provider/providerbootstrapper.py
@@ -25,12 +25,12 @@ import sys
 import requests
 
 from leap.bitmask import provider
-from leap.bitmask import util
 from leap.bitmask.config import flags
 from leap.bitmask.config.providerconfig import ProviderConfig, MissingCACert
 from leap.bitmask.provider import get_provider_path
 from leap.bitmask.provider.pinned import PinnedProviders
 from leap.bitmask.services.abstractbootstrapper import AbstractBootstrapper
+from leap.bitmask.util import get_path_prefix
 from leap.bitmask.util.constants import REQUEST_TIMEOUT
 from leap.bitmask.util.request_helpers import get_content
 from leap.common import ca_bundle
@@ -147,11 +147,11 @@ class ProviderBootstrapper(AbstractBootstrapper):
             res = self._session.get(uri, verify=verify,
                                     timeout=REQUEST_TIMEOUT)
             res.raise_for_status()
-        except requests.exceptions.SSLError as exc:
+        except requests.exceptions.SSLError:
             self._err_msg = self.tr("Provider certificate could "
                                     "not be verified")
             raise
-        except Exception as exc:
+        except Exception:
             # XXX careful!. The error might be also a SSL handshake
             # timeout error, in which case we should retry a couple of times
             # more, for cases where the ssl server gives high latencies.
@@ -172,7 +172,7 @@ class ProviderBootstrapper(AbstractBootstrapper):
 
         headers = {}
         domain = self._domain.encode(sys.getfilesystemencoding())
-        provider_json = os.path.join(util.get_path_prefix(),
+        provider_json = os.path.join(get_path_prefix(),
                                      get_provider_path(domain))
 
         if domain in PinnedProviders.domains() and \

--- a/src/leap/bitmask/provider/tests/test_providerbootstrapper.py
+++ b/src/leap/bitmask/provider/tests/test_providerbootstrapper.py
@@ -48,6 +48,16 @@ from leap.common.testing.basetest import BaseLeapTest
 from leap.common.testing.https_server import where
 
 
+def mkdtemp():
+    """
+    Custom mkdtemp method that uses a custom subdirectory for the leap tests.
+    """
+    sys_temp = tempfile.gettempdir()
+    leap_temp = os.path.join(sys_temp, 'leap-tests')
+    mkdir_p(leap_temp)
+    return tempfile.mkdtemp(dir=leap_temp)
+
+
 class ProviderBootstrapperTest(BaseLeapTest):
     def setUp(self):
         self.pb = ProviderBootstrapper()
@@ -128,8 +138,7 @@ class ProviderBootstrapperTest(BaseLeapTest):
         """
         old_content = "NOT THE NEW CERT"
         new_content = "NEW CERT"
-        new_cert_path = os.path.join(tempfile.mkdtemp(),
-                                     "mynewcert.pem")
+        new_cert_path = os.path.join(mkdtemp(), "mynewcert.pem")
 
         with open(new_cert_path, "w") as c:
             c.write(old_content)
@@ -259,8 +268,7 @@ yV8e
         self.pb._domain = "somedomain"
 
     def test_check_ca_fingerprint_checksout(self):
-        cert_path = os.path.join(tempfile.mkdtemp(),
-                                 "mynewcert.pem")
+        cert_path = os.path.join(mkdtemp(), "mynewcert.pem")
 
         with open(cert_path, "w") as c:
             c.write(self.KNOWN_GOOD_CERT)
@@ -274,8 +282,7 @@ yV8e
         os.unlink(cert_path)
 
     def test_check_ca_fingerprint_fails(self):
-        cert_path = os.path.join(tempfile.mkdtemp(),
-                                 "mynewcert.pem")
+        cert_path = os.path.join(mkdtemp(), "mynewcert.pem")
 
         with open(cert_path, "w") as c:
             c.write(self.KNOWN_GOOD_CERT)
@@ -316,7 +323,7 @@ class ProviderBootstrapperActiveTest(unittest.TestCase):
         # tearDown so we are sure everything is as expected for each
         # test. If we do it inside each specific test, a failure in
         # the test will leave the implementation with the mock.
-        self.old_gpp = util.get_path_prefix
+        self.old_gpp = util.get_bitmask_config_path
 
         self.old_load = ProviderConfig.load
         self.old_save = ProviderConfig.save
@@ -324,7 +331,7 @@ class ProviderBootstrapperActiveTest(unittest.TestCase):
         self.old_api_uri = ProviderConfig.get_api_uri
 
     def tearDown(self):
-        util.get_path_prefix = self.old_gpp
+        util.get_bitmask_config_path = self.old_gpp
         ProviderConfig.load = self.old_load
         ProviderConfig.save = self.old_save
         ProviderConfig.get_api_version = self.old_api_version
@@ -376,7 +383,7 @@ class ProviderBootstrapperActiveTest(unittest.TestCase):
                             paths
         :type path_prefix: str
         """
-        util.get_path_prefix = mock.MagicMock(return_value=path_prefix)
+        util.get_bitmask_config_path = mock.MagicMock(return_value=path_prefix)
         ProviderConfig.get_api_version = mock.MagicMock(
             return_value=api)
         ProviderConfig.get_api_uri = mock.MagicMock(
@@ -405,9 +412,8 @@ class ProviderBootstrapperActiveTest(unittest.TestCase):
         :returns: the provider.json path used
         :rtype: str
         """
-        provider_dir = os.path.join(util.get_path_prefix(),
-                                    "leap", "providers",
-                                    self.pb._domain)
+        provider_dir = os.path.join(util.get_bitmask_config_path(),
+                                    "providers", self.pb._domain)
         mkdir_p(provider_dir)
         provider_path = os.path.join(provider_dir,
                                      "provider.json")
@@ -420,7 +426,7 @@ class ProviderBootstrapperActiveTest(unittest.TestCase):
         'leap.bitmask.config.providerconfig.ProviderConfig.get_domain',
         lambda x: where('testdomain.com'))
     def test_download_provider_info_new_provider(self):
-        self._setup_provider_config_with("1", tempfile.mkdtemp())
+        self._setup_provider_config_with("1", mkdtemp())
         self._setup_providerbootstrapper(True)
 
         self.pb._download_provider_info()
@@ -430,7 +436,7 @@ class ProviderBootstrapperActiveTest(unittest.TestCase):
         'leap.bitmask.config.providerconfig.ProviderConfig.get_ca_cert_path',
         lambda x: where('cacert.pem'))
     def test_download_provider_info_not_modified(self):
-        self._setup_provider_config_with("1", tempfile.mkdtemp())
+        self._setup_provider_config_with("1", mkdtemp())
         self._setup_providerbootstrapper(True)
         provider_path = self._produce_dummy_provider_json()
 
@@ -446,7 +452,7 @@ class ProviderBootstrapperActiveTest(unittest.TestCase):
         'leap.bitmask.config.providerconfig.ProviderConfig.get_domain',
         lambda x: where('testdomain.com'))
     def test_download_provider_info_not_modified_and_no_cacert(self):
-        self._setup_provider_config_with("1", tempfile.mkdtemp())
+        self._setup_provider_config_with("1", mkdtemp())
         self._setup_providerbootstrapper(True)
         provider_path = self._produce_dummy_provider_json()
 
@@ -462,7 +468,7 @@ class ProviderBootstrapperActiveTest(unittest.TestCase):
         'leap.bitmask.config.providerconfig.ProviderConfig.get_ca_cert_path',
         lambda x: where('cacert.pem'))
     def test_download_provider_info_modified(self):
-        self._setup_provider_config_with("1", tempfile.mkdtemp())
+        self._setup_provider_config_with("1", mkdtemp())
         self._setup_providerbootstrapper(True)
         provider_path = self._produce_dummy_provider_json()
 
@@ -477,7 +483,7 @@ class ProviderBootstrapperActiveTest(unittest.TestCase):
         'leap.bitmask.config.providerconfig.ProviderConfig.get_ca_cert_path',
         lambda x: where('cacert.pem'))
     def test_download_provider_info_unsupported_api_raises(self):
-        self._setup_provider_config_with("9999999", tempfile.mkdtemp())
+        self._setup_provider_config_with("9999999", mkdtemp())
         self._setup_providerbootstrapper(False)
         self._produce_dummy_provider_json()
 
@@ -488,8 +494,7 @@ class ProviderBootstrapperActiveTest(unittest.TestCase):
         'leap.bitmask.config.providerconfig.ProviderConfig.get_ca_cert_path',
         lambda x: where('cacert.pem'))
     def test_download_provider_info_unsupported_api(self):
-        self._setup_provider_config_with(provider.SUPPORTED_APIS[0],
-                                         tempfile.mkdtemp())
+        self._setup_provider_config_with(provider.SUPPORTED_APIS[0], mkdtemp())
         self._setup_providerbootstrapper(False)
         self._produce_dummy_provider_json()
 

--- a/src/leap/bitmask/services/__init__.py
+++ b/src/leap/bitmask/services/__init__.py
@@ -28,7 +28,7 @@ from leap.bitmask.crypto.srpauth import SRPAuth
 from leap.bitmask.util.constants import REQUEST_TIMEOUT
 from leap.bitmask.util.privilege_policies import is_missing_policy_permissions
 from leap.bitmask.util.request_helpers import get_content
-from leap.bitmask import util
+from leap.bitmask.util import get_bitmask_config_path
 
 from leap.common.check import leap_assert
 from leap.common.config.baseconfig import BaseConfig
@@ -108,10 +108,8 @@ def download_service_config(provider_config, service_config,
     service_name = service_config.name
     service_json = "{0}-service.json".format(service_name)
     headers = {}
-    mtime = get_mtime(os.path.join(util.get_path_prefix(),
-                                   "leap", "providers",
-                                   provider_config.get_domain(),
-                                   service_json))
+    mtime = get_mtime(os.path.join(get_bitmask_config_path(), "providers",
+                                   provider_config.get_domain(), service_json))
 
     if download_if_needed and mtime:
         headers['if-modified-since'] = mtime

--- a/src/leap/bitmask/services/__init__.py
+++ b/src/leap/bitmask/services/__init__.py
@@ -150,7 +150,7 @@ def download_service_config(provider_config, service_config,
     service_config.set_api_version(api_version)
 
     # Not modified
-    service_path = ("leap", "providers", provider_config.get_domain(),
+    service_path = ("bitmask", "providers", provider_config.get_domain(),
                     service_json)
     if res.status_code == 304:
         logger.debug(

--- a/src/leap/bitmask/services/eip/eipconfig.py
+++ b/src/leap/bitmask/services/eip/eipconfig.py
@@ -28,7 +28,7 @@ from leap.bitmask.config import flags
 from leap.bitmask.config.providerconfig import ProviderConfig
 from leap.bitmask.services import ServiceConfig
 from leap.bitmask.services.eip.eipspec import get_schema
-from leap.bitmask.util import get_path_prefix
+from leap.bitmask.util import get_bitmask_config_path
 from leap.common.check import leap_assert, leap_assert_type
 
 logger = logging.getLogger(__name__)
@@ -47,10 +47,10 @@ def get_eipconfig_path(domain, relative=True):
     """
     leap_assert(domain is not None, "get_eipconfig_path: We need a domain")
 
-    path = os.path.join("leap", "providers", domain, "eip-service.json")
+    path = os.path.join("providers", domain, "eip-service.json")
 
     if not relative:
-        path = os.path.join(get_path_prefix(), path)
+        path = os.path.join(get_bitmask_config_path(), path)
 
     return path
 
@@ -312,8 +312,7 @@ class EIPConfig(ServiceConfig):
         leap_assert(providerconfig, "We need a provider")
         leap_assert_type(providerconfig, ProviderConfig)
 
-        cert_path = os.path.join(get_path_prefix(),
-                                 "leap", "providers",
+        cert_path = os.path.join(get_bitmask_config_path(), "providers",
                                  providerconfig.get_domain(),
                                  "keys", "client", "openvpn.pem")
 

--- a/src/leap/bitmask/services/eip/tests/test_eipbootstrapper.py
+++ b/src/leap/bitmask/services/eip/tests/test_eipbootstrapper.py
@@ -46,6 +46,16 @@ from leap.common.testing.basetest import BaseLeapTest
 from leap.common.files import mkdir_p
 
 
+def mkdtemp():
+    """
+    Custom mkdtemp method that uses a custom subdirectory for the leap tests.
+    """
+    sys_temp = tempfile.gettempdir()
+    leap_temp = os.path.join(sys_temp, 'leap-tests')
+    mkdir_p(leap_temp)
+    return tempfile.mkdtemp(dir=leap_temp)
+
+
 class EIPBootstrapperActiveTest(BaseLeapTest):
     @classmethod
     def setUpClass(cls):
@@ -61,13 +71,13 @@ class EIPBootstrapperActiveTest(BaseLeapTest):
 
     def setUp(self):
         self.eb = EIPBootstrapper()
-        self.old_pp = util.get_path_prefix
+        self.old_pp = util.get_bitmask_config_path
         self.old_save = EIPConfig.save
         self.old_load = EIPConfig.load
         self.old_si = SRPAuth.get_session_id
 
     def tearDown(self):
-        util.get_path_prefix = self.old_pp
+        util.bitmask_config_path = self.old_pp
         EIPConfig.save = self.old_save
         EIPConfig.load = self.old_load
         SRPAuth.get_session_id = self.old_si
@@ -97,17 +107,15 @@ class EIPBootstrapperActiveTest(BaseLeapTest):
         # of this test
         pc.get_ca_cert_path = mock.MagicMock(return_value=False)
 
-        path_prefix = tempfile.mkdtemp()
-        util.get_path_prefix = mock.MagicMock(return_value=path_prefix)
+        path_prefix = mkdtemp()
+        util.get_bitmask_config_path = mock.MagicMock(return_value=path_prefix)
         EIPConfig.save = mock.MagicMock()
         EIPConfig.load = mock.MagicMock()
 
         self.eb._download_if_needed = ifneeded
 
-        provider_dir = os.path.join(util.get_path_prefix(),
-                                    "leap",
-                                    "providers",
-                                    pc.get_domain())
+        provider_dir = os.path.join(util.get_bitmask_config_path(),
+                                    "providers", pc.get_domain())
         mkdir_p(provider_dir)
         eip_config_path = os.path.join(provider_dir,
                                        "eip-service.json")
@@ -184,17 +192,15 @@ class EIPBootstrapperActiveTest(BaseLeapTest):
         pc.get_api_version = mock.MagicMock(return_value="1")
         pc.get_ca_cert_path = mock.MagicMock(return_value=False)
 
-        path_prefix = tempfile.mkdtemp()
-        util.get_path_prefix = mock.MagicMock(return_value=path_prefix)
+        path_prefix = mkdtemp()
+        util.bitmask_config_path = mock.MagicMock(return_value=path_prefix)
         EIPConfig.save = mock.MagicMock()
         EIPConfig.load = mock.MagicMock()
 
         self.eb._download_if_needed = ifneeded
 
-        provider_dir = os.path.join(util.get_path_prefix(),
-                                    "leap",
-                                    "providers",
-                                    "somedomain")
+        provider_dir = os.path.join(util.get_bitmask_config_path(),
+                                    "providers", "somedomain")
         mkdir_p(provider_dir)
         eip_cert_path = os.path.join(provider_dir,
                                      "cert")

--- a/src/leap/bitmask/services/eip/tests/test_eipconfig.py
+++ b/src/leap/bitmask/services/eip/tests/test_eipconfig.py
@@ -268,7 +268,7 @@ class EIPConfigTest(BaseLeapTest):
         provider_domain = 'test.provider.com'
         provider_config.get_domain = Mock(return_value=provider_domain)
 
-        expected_path = os.path.join('leap', 'providers',
+        expected_path = os.path.join('bitmask', 'providers',
                                      provider_domain, 'keys', 'client',
                                      'openvpn.pem')
 
@@ -286,7 +286,7 @@ class EIPConfigTest(BaseLeapTest):
         provider_domain = 'test.provider.com'
         provider_config.get_domain = Mock(return_value=provider_domain)
 
-        expected_path = os.path.join('leap', 'providers',
+        expected_path = os.path.join('bitmask', 'providers',
                                      provider_domain, 'keys', 'client',
                                      'openvpn.pem')
 

--- a/src/leap/bitmask/services/mail/smtpconfig.py
+++ b/src/leap/bitmask/services/mail/smtpconfig.py
@@ -23,7 +23,7 @@ import os
 from leap.bitmask.config.providerconfig import ProviderConfig
 from leap.bitmask.services import ServiceConfig
 from leap.bitmask.services.mail.smtpspec import get_schema
-from leap.bitmask.util import get_path_prefix
+from leap.bitmask.util import get_bitmask_config_path
 from leap.common.check import leap_assert, leap_assert_type
 
 logger = logging.getLogger(__name__)
@@ -62,8 +62,7 @@ class SMTPConfig(ServiceConfig):
         leap_assert(providerconfig, "We need a provider")
         leap_assert_type(providerconfig, ProviderConfig)
 
-        cert_path = os.path.join(get_path_prefix(),
-                                 "leap", "providers",
+        cert_path = os.path.join(get_bitmask_config_path(), "providers",
                                  providerconfig.get_domain(),
                                  "keys", "client", "smtp.pem")
 

--- a/src/leap/bitmask/services/soledad/soledadbootstrapper.py
+++ b/src/leap/bitmask/services/soledad/soledadbootstrapper.py
@@ -37,8 +37,8 @@ from leap.bitmask.crypto.srpauth import SRPAuth
 from leap.bitmask.services import download_service_config
 from leap.bitmask.services.abstractbootstrapper import AbstractBootstrapper
 from leap.bitmask.services.soledad.soledadconfig import SoledadConfig
+from leap.bitmask.util import get_bitmask_config_path, get_path_prefix
 from leap.bitmask.util import first, is_file, is_empty_file, make_address
-from leap.bitmask.util import get_path_prefix
 from leap.bitmask.platform_init import IS_WIN
 from leap.common.check import leap_assert, leap_assert_type, leap_check
 from leap.common.files import which
@@ -106,7 +106,7 @@ def get_db_paths(uuid):
     :return: a tuple with secrets, local_db paths
     :rtype: tuple
     """
-    prefix = os.path.join(get_path_prefix(), "leap", "soledad")
+    prefix = os.path.join(get_bitmask_config_path(), "soledad")
     secrets = "%s/%s.secret" % (prefix, uuid)
     local_db = "%s/%s.db" % (prefix, uuid)
 

--- a/src/leap/bitmask/util/__init__.py
+++ b/src/leap/bitmask/util/__init__.py
@@ -59,6 +59,10 @@ def get_path_prefix():
     return common_get_path_prefix(flags.STANDALONE)
 
 
+def get_bitmask_config_path():
+    return os.path.join(common_get_path_prefix(flags.STANDALONE), 'bitmask')
+
+
 def get_modification_ts(path):
     """
     Gets modification time of a file.

--- a/src/leap/bitmask/util/__init__.py
+++ b/src/leap/bitmask/util/__init__.py
@@ -20,6 +20,7 @@ Some small and handy functions.
 import datetime
 import itertools
 import os
+import shutil
 
 from leap.bitmask.config import flags
 from leap.common.config import get_path_prefix as common_get_path_prefix
@@ -56,11 +57,50 @@ def flatten(things):
 # leap repetitive chores
 
 def get_path_prefix():
+    """
+    Return the bitmask prefix folder used as a base path for data storage.
+
+    :rtype: str
+    """
     return common_get_path_prefix(flags.STANDALONE)
 
 
 def get_bitmask_config_path():
+    """
+    Return the bitmask configuration folder used to store all the application
+    data.
+
+    :rtype: str
+    """
     return os.path.join(common_get_path_prefix(flags.STANDALONE), 'bitmask')
+
+
+def _move_config_leap_to_bitmask():
+    """
+    Migration helper to move the old config folder path to the new path name.
+    ~/.config/leap/ -> ~/.config/bitmask/
+
+    :return: True if succeeded, False if not neccessary.
+    :rtype: Bool
+
+    May rise IOError if the new path exists.
+    """
+    OLD_CONFIG_PATH = os.path.join(get_path_prefix(), 'leap')
+    NEW_CONFIG_PATH = os.path.join(get_path_prefix(), 'bitmask')
+
+    if not os.path.exists(OLD_CONFIG_PATH):
+        return False
+
+    if os.path.exists(NEW_CONFIG_PATH):
+        msg = ("Migration script failed: {0} -> {1}\n"
+               "Can't migrate config folder since {1} exists.\n"
+               "You need to choose whether you want to keep configs on {0} or"
+               "{1} in order to fix this conflict.")
+        msg = msg.format(OLD_CONFIG_PATH, NEW_CONFIG_PATH)
+        raise IOError(msg)
+
+    shutil.move(OLD_CONFIG_PATH, NEW_CONFIG_PATH)
+    return True
 
 
 def get_modification_ts(path):


### PR DESCRIPTION
**DO NOT MERGE** ... Work in progress.
See: https://leap.se/code/issues/6647

We should use either `~/.config/leap` or `~/.config/bitmask` (in that order?).
Right now this pullreq does:
* try to rename the `leap` folder to `bitmask` and then start from that folder.
* use the `bitmask` name for the config folder.
* fix tests to match this changes (2 still broken)