### PR TITLE
[bug] fix concatenation of full_user_id to make mail work

### DIFF
--- a/changes/bug_6759_fix_user_id
+++ b/changes/bug_6759_fix_user_id
@@ -1,0 +1,1 @@
+- #6759 Fix formation of full_userid, allowing the right id to be passed to keymanager and mail services

--- a/src/leap/bitmask/gui/mainwindow.py
+++ b/src/leap/bitmask/gui/mainwindow.py
@@ -1193,7 +1193,12 @@ class MainWindow(QtGui.QMainWindow, SignalTracker):
 
         user = self._login_widget.get_logged_user()
         domain = self._providers.get_selected_provider()
-        full_user_id = make_address(user, domain)
+
+        # XXX fix for 0.8.2: this user id has changed!
+        # BUG -- do not merge into develop, it's already fixed there.
+        # full_user_id = make_address(user, domain)
+        full_user_id = user
+
         self._mail_conductor.userid = full_user_id
         self._start_eip_bootstrap()
         self.ui.action_create_new_account.setEnabled(True)
@@ -1311,7 +1316,9 @@ class MainWindow(QtGui.QMainWindow, SignalTracker):
         provider_domain = self._providers.get_selected_provider()
 
         if flags.OFFLINE:
-            full_user_id = make_address(username, provider_domain)
+            # BUG --- fix for 0.8.2
+            # full_user_id = make_address(username, provider_domain)
+            full_user_id = username
             uuid = self._settings.get_uuid(full_user_id)
             self._mail_conductor.userid = full_user_id
 

--- a/src/leap/bitmask/services/mail/smtpbootstrapper.py
+++ b/src/leap/bitmask/services/mail/smtpbootstrapper.py
@@ -152,7 +152,7 @@ class SMTPBootstrapper(AbstractBootstrapper):
         self._provider_config = ProviderConfig.get_provider_config(domain)
         self._keymanager = keymanager
         self._smtp_config = SMTPConfig()
-        self._userid = userid
+        self._userid = str(userid)
         self._download_if_needed = download_if_needed
 
         try:


### PR DESCRIPTION
At some moment, the semantics of the username that we pick from the
login widget changed, so that there's a duplication of the domain part
in the full_user_id that we were passing to the keymanager and the mail
services.

This fix has already been done in the current develop branch (for next
release 0.9.0), so there's no need to port it when merging it back.

While it is true that there's no official release of the client supporting
mail yet, this was an easy fix to port so we will do a 0.8.2
bugfix release so that the 0.8 branch can be used experimentally to test
against development providers. This doesn't mean that you can expect
support on the 0.8.x branch yet, it's only that there is one less bug in
here :)

Resolves: #6759
Releases: 0.8.2