### PR TITLE
[bug] handle user cancel keyring open operation

### DIFF
--- a/changes/bug-6682_failure-to-unlock-keyring-freezes-bitmask
+++ b/changes/bug-6682_failure-to-unlock-keyring-freezes-bitmask
@@ -1,0 +1,1 @@
+- Handle user cancel keyring open operation, this prevents a bitmask freeze. Closes bug #6682.

--- a/src/leap/bitmask/gui/login.py
+++ b/src/leap/bitmask/gui/login.py
@@ -32,6 +32,7 @@ The login sequence is the following:
 """
 import logging
 
+from keyring.errors import InitError as KeyringInitError
 from PySide import QtCore, QtGui
 from ui_login import Ui_LoginWidget
 
@@ -365,6 +366,9 @@ class LoginWidget(QtGui.QWidget, SignalTracker):
                 # Only save the username if it was saved correctly in
                 # the keyring
                 self._settings.set_user(full_user_id)
+            except KeyringInitError as e:
+                logger.error("Failed to unlock keyring, maybe the user "
+                             "cancelled the operation {0!r}".format(e))
             except Exception as e:
                 logger.exception("Problem saving data to keyring. %r" % (e,))
 
@@ -653,6 +657,9 @@ class LoginWidget(QtGui.QWidget, SignalTracker):
             saved_password = keyring.get_password(self.KEYRING_KEY, u_user)
         except ValueError as e:
             logger.debug("Incorrect Password. %r." % (e,))
+        except KeyringInitError as e:
+            logger.error("Failed to unlock keyring, maybe the user "
+                         "cancelled the operation {0!r}".format(e))
 
         if saved_password is not None:
             self.set_password(saved_password)


### PR DESCRIPTION
Catch the `keyring.errors.InitError` exception.
The automatic login sequence now stops correctly instead of freezing if
the user cancel the keyring open operation.

- Resolves: #6682