### PR TITLE
[bug] do not disable autostart on system quit()

### DIFF
--- a/changes/bug_fix-bitmask-autostart
+++ b/changes/bug_fix-bitmask-autostart
@@ -1,0 +1,1 @@
+- Do not disable autostart if the quit is triggered by a system logout. Resolves Bug #6424.

--- a/src/leap/bitmask/frontend_app.py
+++ b/src/leap/bitmask/frontend_app.py
@@ -51,7 +51,13 @@ def signal_handler(window, pid, signum, frame):
     if pid == my_pid:
         pname = multiprocessing.current_process().name
         logger.debug("{0}: SIGNAL #{1} catched.".format(pname, signum))
-        window.quit()
+        disable_autostart = True
+        if signum == 15:  # SIGTERM
+            # Do not disable autostart on SIGTERM since this is the signal that
+            # the system sends to bitmask when the user asks to do a system
+            # logout.
+            disable_autostart = False
+        window.quit(disable_autostart=disable_autostart)
 
 
 def run_frontend(options, flags_dict, backend_pid=None):

--- a/src/leap/bitmask/gui/mainwindow.py
+++ b/src/leap/bitmask/gui/mainwindow.py
@@ -1054,7 +1054,7 @@ class MainWindow(QtGui.QMainWindow, SignalTracker):
         if not e.spontaneous():
             # if the system requested the `close` then we should quit.
             self._system_quit = True
-            self.quit()
+            self.quit(disable_autostart=False)
             return
 
         if QtGui.QSystemTrayIcon.isSystemTrayAvailable() and \
@@ -1622,18 +1622,24 @@ class MainWindow(QtGui.QMainWindow, SignalTracker):
         logger.debug('Terminating vpn')
         self._backend.eip_stop(shutdown=True)
 
-    def quit(self):
+    def quit(self, disable_autostart=True):
         """
         Start the quit sequence and wait for services to finish.
         Cleanup and close the main window before quitting.
+
+        :param disable_autostart: whether we should disable the autostart
+                                  feature or not
+        :type disable_autostart: bool
         """
         if self._quitting:
             return
 
+        if disable_autostart:
+            autostart.set_autostart(False)
+
         self._quitting = True
         self._close_to_tray = False
         logger.debug('Quitting...')
-        autostart.set_autostart(False)
 
         # first thing to do quitting, hide the mainwindow and show tooltip.
         self.hide()


### PR DESCRIPTION
If the `quit()` call is triggered by the system logout we should not disable
the autostart. Otherwise bitmask won't autostart on the next session
start.

- Resolves: #6424