### PR TITLE
[bug] handle disabled registration, error 403.

### DIFF
--- a/changes/bug-6594_handle-disabled-registration
+++ b/changes/bug-6594_handle-disabled-registration
@@ -1,0 +1,1 @@
+- Handle disabled registration on provider. Closes Bug #6594.

--- a/src/leap/bitmask/backend/api.py
+++ b/src/leap/bitmask/backend/api.py
@@ -146,6 +146,7 @@ SIGNALS = (
     "srp_password_change_badpw",
     "srp_password_change_error",
     "srp_password_change_ok",
+    "srp_registration_disabled",
     "srp_registration_failed",
     "srp_registration_finished",
     "srp_registration_taken",

--- a/src/leap/bitmask/backend/leapsignaler.py
+++ b/src/leap/bitmask/backend/leapsignaler.py
@@ -109,6 +109,7 @@ class LeapSignaler(SignalerQt):
     srp_password_change_badpw = QtCore.Signal()
     srp_password_change_error = QtCore.Signal()
     srp_password_change_ok = QtCore.Signal()
+    srp_registration_disabled = QtCore.Signal()
     srp_registration_failed = QtCore.Signal()
     srp_registration_finished = QtCore.Signal()
     srp_registration_taken = QtCore.Signal()

--- a/src/leap/bitmask/config/providerconfig.py
+++ b/src/leap/bitmask/config/providerconfig.py
@@ -69,6 +69,7 @@ class ProviderConfig(BaseConfig):
         details["description"] = config.get_description(lang=lang)
         details["enrollment_policy"] = config.get_enrollment_policy()
         details["services"] = config.get_services()
+        details["allow_registration"] = config.get_allow_registration()
 
         services = []
         for service in config.get_services():
@@ -176,6 +177,15 @@ class ProviderConfig(BaseConfig):
         """
         services = self._safe_get_value("services")
         return services
+
+    def get_allow_registration(self):
+        """
+        Return whether the registration is allowed or not in the provider.
+
+        :rtype: bool
+        """
+        service = self._safe_get_value("service")
+        return service['allow_registration']
 
     def get_ca_cert_path(self, about_to_download=False):
         """

--- a/src/leap/bitmask/crypto/srpregister.py
+++ b/src/leap/bitmask/crypto/srpregister.py
@@ -153,6 +153,7 @@ class SRPRegister(QtCore.QObject):
 
     STATUS_OK = (200, 201)
     STATUS_TAKEN = 422
+    STATUS_FORBIDDEN = 403
 
     def __init__(self, signaler=None,
                  provider_config=None, register_path="users"):
@@ -204,6 +205,8 @@ class SRPRegister(QtCore.QObject):
             self._signaler.signal(self._signaler.srp_registration_finished)
         elif status_code == self.STATUS_TAKEN:
             self._signaler.signal(self._signaler.srp_registration_taken)
+        elif status_code == self.STATUS_FORBIDDEN:
+            self._signaler.signal(self._signaler.srp_registration_disabled)
         else:
             self._signaler.signal(self._signaler.srp_registration_failed)
 


### PR DESCRIPTION
If the user wants to register a new account we check whether the
provider allows registration or not right after getting the
`provider.json` file and show an error msg on the wizard if not allowed.

Also, there is a new signal to handle the error raised by the server if
a registration attempt is made but is rejected with error `403`.

- Resolves: #6594