### PR TITLE
[bug] change the ip command location to /sbin/

### DIFF
--- a/changes/bug-6894_change-ip-command-location
+++ b/changes/bug-6894_change-ip-command-location
@@ -1,0 +1,1 @@
+- Change 'ip' command location to support Fedora/RHEL distros. Closes #6894.

--- a/pkg/linux/bitmask-root
+++ b/pkg/linux/bitmask-root
@@ -73,7 +73,7 @@ def get_no_group_name():
             return None
 
 
-VERSION = "5"
+VERSION = "6"
 SCRIPT = "bitmask-root"
 NAMESERVER = "10.42.0.1"
 BITMASK_CHAIN = "bitmask"
@@ -85,7 +85,7 @@ LOCAL_INTERFACE = "lo"
 IMAP_PORT = "1984"
 SMTP_PORT = "2013"
 
-IP = "/bin/ip"
+IP = "/sbin/ip"
 IPTABLES = "/sbin/iptables"
 IP6TABLES = "/sbin/ip6tables"
 


### PR DESCRIPTION
Change the `ip` command location to support Fedora/RHEL distros.
`/bin/ip` is pressent on Debian/Ubuntu but not on Fedora.
`/sbin/ip` is a symlink to `/bin/ip` on Debian/Ubuntu and a binary on Fedora.

- Resolves: #6894