### PR TITLE
[bug] two small soledad sync issues

### DIFF
--- a/changes/bug-syncing_retry
+++ b/changes/bug-syncing_retry
@@ -1,0 +1,1 @@
+- Fix soledad bootstrap sync retries.


### PR DESCRIPTION
* Don't check if soledad is still syncing for timeout, it seems that if
  it fails it might not have the flag still unset. Check instead if the
  callback deferred has being called.
* Count retries properly.

I still have to test it more, and maybe we should not check the deferred but fix soledad syncing flag.