### PR TITLE
[bug] move events server init to backend

### DIFF
--- a/src/leap/bitmask/app.py
+++ b/src/leap/bitmask/app.py
@@ -57,7 +57,6 @@ from leap.bitmask.services.mail import plumber
 from leap.bitmask.util import leap_argparse, flags_to_dict
 from leap.bitmask.util.requirement_checker import check_requirements
 
-from leap.common.events import server as event_server
 from leap.mail import __version__ as MAIL_VERSION
 
 import codecs
@@ -152,12 +151,6 @@ def start_app():
     # and show logs there. it normally will exit there if we got that path.
     # XXX mail repair commands disabled for now
     # do_mail_plumbing(opts)
-
-    try:
-        event_server.ensure_server()
-    except Exception as e:
-        # We don't even have logger configured in here
-        print "Could not ensure server: %r" % (e,)
 
     PLAY_NICE = os.environ.get("LEAP_NICE")
     if PLAY_NICE and PLAY_NICE.isdigit():

--- a/src/leap/bitmask/backend/components.py
+++ b/src/leap/bitmask/backend/components.py
@@ -829,7 +829,6 @@ class Soledad(object):
             logger.debug("Cancelling soledad defer.")
             self._soledad_defer.cancel()
             self._soledad_defer = None
-            zope.proxy.setProxiedObject(self._soledad_proxy, None)
 
     def close(self):
         """

--- a/src/leap/bitmask/backend_app.py
+++ b/src/leap/bitmask/backend_app.py
@@ -21,6 +21,8 @@ import logging
 import multiprocessing
 import signal
 
+from leap.common.events import server as event_server
+
 from leap.bitmask.backend.leapbackend import LeapBackend
 from leap.bitmask.backend.utils import generate_zmq_certificates
 from leap.bitmask.config import flags
@@ -67,6 +69,9 @@ def run_backend(bypass_checks=False, flags_dict=None, frontend_pid=None):
 
     if flags_dict is not None:
         dict_to_flags(flags_dict)
+
+    # start the events server
+    event_server.ensure_server()
 
     backend = LeapBackend(bypass_checks=bypass_checks,
                           frontend_pid=frontend_pid)


### PR DESCRIPTION
If the events server is initialized in a different process than the backend,
the txzmq socket raises an "zmq.error.ZMQError: Interrupted system call"
exception during the events server initialization. Despite that, communication
seems to work flawlessly after the initialization.

Moving the events server initialization to the same process as the backend
causes the exception to not be raised during events server intialization.