### PR TITLE
bug regression: polkit agent is not automatically launched #6652

### DIFF
--- a/src/leap/bitmask/platform_init/initializers.py
+++ b/src/leap/bitmask/platform_init/initializers.py
@@ -202,6 +202,7 @@ def check_polkit():
 
     try:
         LinuxPolicyChecker.maybe_pkexec()
+        return True
     except Exception:
         logger.error("No polkit agent running.")
 


### PR DESCRIPTION
Polkit was being launched and detected correctly, but Bitmask didn't
propagate this result to upper layers, so mainwindow thought the
platform wasn't initialized and then quitted without explanation.

Tested on debian testing, on June 5th 2015, using i3 window manager.

- Resolves: #6652