### PR TITLE
[bug] fix attribute error on mail conductor

### DIFF
--- a/changes/bug_7093-fix-controller-attribute-error
+++ b/changes/bug_7093-fix-controller-attribute-error
@@ -1,0 +1,1 @@
+- Fix controller attribute error. Closes: #7093

--- a/src/leap/bitmask/services/mail/conductor.py
+++ b/src/leap/bitmask/services/mail/conductor.py
@@ -94,7 +94,9 @@ class IMAPControl(object):
         """
         On mail client logged in, fetch incoming mail.
         """
-        self._controller.imap_service_fetch()
+        # XXX needs to be adapted to the new-ish incoming mail service.
+        # Doing nothing for now, this could be moved to mail package itself.
+        logger.debug("A MUA has logged in, should react by forcing a fetch.")
 
     def _on_imap_connecting(self):
         """


### PR DESCRIPTION
due to remaining bits that had not been changed after a refactor.

- Resolves: #7093