### PR TITLE
[pkg] add missing taskthread dependency

### DIFF
--- a/pkg/requirements.pip
+++ b/pkg/requirements.pip
@@ -30,3 +30,5 @@ leap.mail>=0.3.9
 
 # Remove this when u1db fixes its dependency on oauth
 oauth
+
+taskthread


### PR DESCRIPTION
This dependency was previously installed through soledad, but it
doesn't use that lib anymore.