### PR TITLE
[bug] don't run event server on the standalone

### DIFF
--- a/changes/bug-7126_ensure-server-breaks
+++ b/changes/bug-7126_ensure-server-breaks
@@ -1,0 +1,1 @@
+- Don't run the event server on the backend for the standalone bundle since the launcher takes care of that. Closes #7126.

--- a/src/leap/bitmask/backend_app.py
+++ b/src/leap/bitmask/backend_app.py
@@ -70,8 +70,13 @@ def run_backend(bypass_checks=False, flags_dict=None, frontend_pid=None):
     if flags_dict is not None:
         dict_to_flags(flags_dict)
 
-    # start the events server
-    event_server.ensure_server()
+    # HACK we should be able to run the ensure_server anyway but right now it
+    # breaks if we run it twice.
+    if not flags.STANDALONE:
+        # start the events server
+        # This is not needed for the standalone bundle since the launcher takes
+        # care of it.
+        event_server.ensure_server()
 
     backend = LeapBackend(bypass_checks=bypass_checks,
                           frontend_pid=frontend_pid)


### PR DESCRIPTION
We don't need to run the event server on the backend if we are running
from the standalone bundle since the launcher takes care of that.

- Related: #7126