### PR TITLE
[bug] make sure log path exists

### DIFF
--- a/src/leap/bitmask/logs/utils.py
+++ b/src/leap/bitmask/logs/utils.py
@@ -28,12 +28,17 @@ from leap.bitmask.logs.safezmqhandler import SafeZMQHandler
 # from leap.bitmask.logs.streamtologger import StreamToLogger
 from leap.bitmask.platform_init import IS_WIN
 from leap.bitmask.util import get_path_prefix
+from leap.common.files import mkdir_p
 
 import logbook
 from logbook.more import ColorizedStderrHandler
 
 
-BITMASK_LOG_FILE = os.path.join(get_path_prefix(), "leap", 'bitmask.log')
+# NOTE: make sure that the folder exists, the logger is created before saving
+# settings on the first run.
+_base = os.path.join(get_path_prefix(), "leap")
+mkdir_p(_base)
+BITMASK_LOG_FILE = os.path.join(_base, 'bitmask.log')
 
 
 def get_logger(perform_rollover=False):


### PR DESCRIPTION
The logger is the first thing to be created and on a first run the
config path won't exist. This way we make sure the path always exists.