### PR TITLE
[bug] log contains exported PGP private key

### DIFF
--- a/changes/bug-7185_log-contains-exported-pgp-private-key
+++ b/changes/bug-7185_log-contains-exported-pgp-private-key
@@ -1,0 +1,1 @@
+- Log contains exported PGP Private Key. Closes bug #7185.


### PR DESCRIPTION
Due to #7139 (the logbook log centralizer) logs from 3rd party libs are
included in the centralized logs with lots of debug information and we
don't want that.
We use the existing silencer to exclude logs that are not from leap
modules.

- Resolves: #7185