### PR TITLE
[bug] handle eip-config not providing locations

### DIFF
--- a/changes/bug-7281_support-no-locations-for-eip
+++ b/changes/bug-7281_support-no-locations-for-eip
@@ -1,0 +1,1 @@
+- Closes bug #7281. Support a provider not providing location for the eip gateways.

--- a/src/leap/bitmask/backend/components.py
+++ b/src/leap/bitmask/backend/components.py
@@ -628,7 +628,9 @@ class EIP(object):
         # this only works for selecting the first gateway, as we're
         # currently doing.
         ccodes = gateway_selector.get_gateways_country_code()
-        gateway_ccode = ccodes[gateways[0]]
+        gateway_ccode = ''  # '' instead of None due to needed signal argument
+        if ccodes is not None:
+            gateway_ccode = ccodes[gateways[0]]
 
         self._signaler.signal(self._signaler.eip_get_gateway_country_code,
                               gateway_ccode)

--- a/src/leap/bitmask/services/eip/eipconfig.py
+++ b/src/leap/bitmask/services/eip/eipconfig.py
@@ -161,12 +161,17 @@ class VPNGatewaySelector(object):
     def get_gateways_country_code(self):
         """
         Return a dict with ipaddress -> country code mapping.
+        Return None if there are no locations specified.
 
-        :rtype: dict
+        :rtype: dict or None
         """
         country_codes = {}
 
         locations = self._eipconfig.get_locations()
+
+        if not locations:
+            return
+
         gateways = self._eipconfig.get_gateways()
 
         for idx, gateway in enumerate(gateways):


### PR DESCRIPTION
Is valid for a provider not to provide locations for their gateways.

- Resolves: #7281