### PR TITLE
[feat] enable '--danger' for stable versions

### DIFF
--- a/src/leap/bitmask/util/leap_argparse.py
+++ b/src/leap/bitmask/util/leap_argparse.py
@@ -78,20 +78,20 @@ def build_parser():
     # XXX not yet updated to new mail api for mail 0.4.0
 
     # parser.add_argument('--acct', metavar="user@provider",
-                         #nargs='?',
-                         #action="store", dest="acct",
-                         #help='Manipulate mailboxes for this account')
+    #                     nargs='?',
+    #                     action="store", dest="acct",
+    #                     help='Manipulate mailboxes for this account')
     # parser.add_argument('-r', '--repair-mailboxes', default=False,
-                         #action="store_true", dest="repair",
-                         #help='Repair mailboxes for a given account. '
-                             #'Use when upgrading versions after a schema '
-                             #'change. Use with --acct')
+    #                     action="store_true", dest="repair",
+    #                     help='Repair mailboxes for a given account. '
+    #                     'Use when upgrading versions after a schema '
+    #                     'change. Use with --acct')
     # parser.add_argument('--import-maildir', metavar="/path/to/Maildir",
-                          #nargs='?',
-                          #action="store", dest="import_maildir",
-                          #help='Import the given maildir. Use with the '
-                               #'--to-mbox flag to import to folders other '
-                               #'than INBOX. Use with --acct')
+    #                     nargs='?',
+    #                     action="store", dest="import_maildir",
+    #                     help='Import the given maildir. Use with the '
+    #                     '--to-mbox flag to import to folders other '
+    #                     'than INBOX. Use with --acct')
 
     if not IS_RELEASE_VERSION:
         help_text = ("Bypasses the certificate check during provider "

--- a/src/leap/bitmask/util/leap_argparse.py
+++ b/src/leap/bitmask/util/leap_argparse.py
@@ -19,8 +19,6 @@ Parses the command line arguments passed to the application.
 """
 import argparse
 
-from leap.bitmask import IS_RELEASE_VERSION
-
 
 def build_parser():
     """
@@ -93,11 +91,10 @@ def build_parser():
     #                     '--to-mbox flag to import to folders other '
     #                     'than INBOX. Use with --acct')
 
-    if not IS_RELEASE_VERSION:
-        help_text = ("Bypasses the certificate check during provider "
-                     "bootstraping, for debugging development servers. "
-                     "Use at your own risk!")
-        parser.add_argument('--danger', action="store_true", help=help_text)
+    help_text = ("INSECURE: Bypasses the certificate check during provider "
+                 "bootstraping, for debugging development servers. "
+                 "USE AT YOUR OWN RISK!")
+    parser.add_argument('--danger', action="store_true", help=help_text)
 
     # optional cert file used to check domains with self signed certs.
     parser.add_argument('--ca-cert-file', metavar="/path/to/cacert.pem",
@@ -131,9 +128,5 @@ def get_options():
     """
     parser = build_parser()
     opts, unknown = parser.parse_known_args()
-
-    # we add this option manually since it's not defined for 'release version'
-    if IS_RELEASE_VERSION:
-        opts.danger = False
 
     return opts


### PR DESCRIPTION
Is useful for new providers to be able to use the stable Bitmask
version with this flag to be able to use custom certificates.

* Resolves: #7250
