### PR TITLE
[test] fix SRP tests

### DIFF
--- a/changes/bug-7343_fix_the_tests
+++ b/changes/bug-7343_fix_the_tests
@@ -1,0 +1,1 @@
+- Clean up and fix the tests (Closes: #7343)

--- a/src/leap/bitmask/crypto/srpregister.py
+++ b/src/leap/bitmask/crypto/srpregister.py
@@ -73,8 +73,9 @@ class SRPRegisterImpl:
         :param password: password for this username
         :type password: str
 
-        :returns: if the registration went ok or not.
-        :rtype: bool
+        :returns: if the registration went ok or not, and the returned status
+                  code of of the request
+        :rtype: (bool, int)
         """
 
         username = username.lower().encode('utf-8')


### PR DESCRIPTION
The tests where using deferToThread to run without need, I remove it
and now it's easier to debug when one test fails.

- Resolves: #7343