### PR TITLE
[feat] load credentials from environment variables

### DIFF
--- a/changes/feature-7419_load-credentials-from-env
+++ b/changes/feature-7419_load-credentials-from-env
@@ -1,0 +1,1 @@
+- Load credentials from environment variables and trigger login. Closes feature #7419.


### PR DESCRIPTION
Look for file defined in the `BITMASK_CREDENTIALS` env variable and load
`provider`, `username` and `password` data.
Trigger login if they were loaded correctly.

The credentials file should look like this:
```
[Credentials]
username = my-account@my-provider.com
password = secret
```
- Resolves: #7419