### PR TITLE
[pkg] add libzmq dependency

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     libffi-dev \
     libsqlite3-dev \
     libssl-dev \
+    libzmq-dev \
     openvpn \
     pyside-tools \
     python-dev \

--- a/docker/leap_bootstrap.sh
+++ b/docker/leap_bootstrap.sh
@@ -48,7 +48,7 @@ apt_install_dependencies() {
     status="installing system dependencies"
     echo "${cc_green}Status: $status...${cc_normal}"
     set -x
-    sudo apt-get install -y git python-dev python-setuptools python-virtualenv python-pip libssl-dev python-openssl libsqlite3-dev g++ openvpn pyside-tools python-pyside libffi-dev
+    sudo apt-get install -y git python-dev python-setuptools python-virtualenv python-pip libssl-dev python-openssl libsqlite3-dev g++ openvpn pyside-tools python-pyside libffi-dev libzmq-dev
     set +x
 }
 


### PR DESCRIPTION
This is needed if we use wheels, since the zmq library is not build as it is when we install from code.