### PR TITLE
[bug] add compatibility for logbook versions < 0.7.0

### DIFF
--- a/src/leap/bitmask/logs/safezmqhandler.py
+++ b/src/leap/bitmask/logs/safezmqhandler.py
@@ -19,9 +19,11 @@ A thread-safe zmq handler for LogBook.
 """
 import json
 import threading
+from distutils import LooseVersion
 
 from logbook.queues import ZeroMQHandler
 from logbook import NOTSET
+from logbook import __version__ as LOGBOOK_VERSION
 
 import zmq
 
@@ -53,8 +55,13 @@ class SafeZMQHandler(ZeroMQHandler):
         # instead of calling the ZeroMQHandler's one.
         # The best approach may be to inherit directly from `logbook.Handler`.
 
-        ZeroMQHandler.__init__(self, uri, level, filter, bubble, context,
-                               multi)
+        args = (self, uri, level, filter, bubble, context)
+
+        # Workaround for an API change: version 0.6.0 in trusty doesn't accepts
+        # the multi parameter.
+        if LooseVersion(LOGBOOK_VERSION) >= LooseVersion('0.7.0'):
+            args += (multi,)
+        ZeroMQHandler.__init__(*args)
 
         current_id = self._get_caller_id()
         # we store the socket created on the parent


### PR DESCRIPTION
for the version in ubuntu trusty, the call for the zeromq handler
initialization gets one less argument