### PR TITLE
[pkg] require Logbook 0.7.0 or newer

### DIFF
--- a/pkg/requirements.pip
+++ b/pkg/requirements.pip
@@ -28,4 +28,4 @@ txzmq
 oauth
 
 taskthread
-logbook
+logbook>=0.7.0


### PR DESCRIPTION
For our logging we need a new logbook feature that was added on 0.7.0.

- Resolves: #7449