### PR TITLE
[bug] correctly return expected value

### DIFF
--- a/changes/bug_7470_fix-service-enabled-method
+++ b/changes/bug_7470_fix-service-enabled-method
@@ -1,0 +1,1 @@
+- Fix bug with password change. Closes: #7470

--- a/src/leap/bitmask/gui/account.py
+++ b/src/leap/bitmask/gui/account.py
@@ -43,7 +43,7 @@ class Account():
         return self._settings.get_enabled_services(self.domain)
 
     def is_email_enabled(self):
-        MX_SERVICE in self.services()
+        return MX_SERVICE in self.services()
 
     def is_eip_enabled(self):
-        EIP_SERVICE in self.services()
+        return EIP_SERVICE in self.services()

--- a/src/leap/bitmask/gui/passwordwindow.py
+++ b/src/leap/bitmask/gui/passwordwindow.py
@@ -203,6 +203,12 @@ class PasswordWindow(QtGui.QDialog, Flashable):
         new_password = self.ui.new_password_lineedit.text()
         logger.debug("SRP password changed successfully.")
 
+        # FIXME ---- both changes need to be made atomically!
+        # if there is some problem changing password in soledad (for instance,
+        # it checks for length), any exception raised will be lost and we will
+        # have an inconsistent state between soledad and srp passwords.
+        # We need to implement rollaback.
+
         if self.is_soledad_needed():
             self._backend.soledad_change_password(new_password=new_password)
         else:


### PR DESCRIPTION
this was returning None, and therefore breaking soledad password change
(since it checks whether mail is enabled before changing soledad pass
after srp pass change).

- Resolves: #7470