### PR TITLE
[bug] track soledad ready state on a shared place

### DIFF
--- a/changes/bug-7474_handle-soledad-ready-properly
+++ b/changes/bug-7474_handle-soledad-ready-properly
@@ -1,0 +1,1 @@
+- Track soledad ready state on a shared place for easy access. Enable password change window. Closes bug #7474.

--- a/src/leap/bitmask/gui/app.py
+++ b/src/leap/bitmask/gui/app.py
@@ -43,6 +43,8 @@ class App(QtGui.QWidget):
         self.signaler = LeapSignaler()
         self.signaler.start()
 
+        self.soledad_started = False
+
         # periodically check if the backend is alive
         self._backend_checker = QtCore.QTimer(self)
         self._backend_checker.timeout.connect(self._check_backend_status)

--- a/src/leap/bitmask/gui/mainwindow.py
+++ b/src/leap/bitmask/gui/mainwindow.py
@@ -201,8 +201,6 @@ class MainWindow(QtGui.QMainWindow, SignalTracker):
         self._login_widget.login_offline_finished.connect(
             self._maybe_run_soledad_setup_checks)
 
-        self._soledad_started = False
-
         # This is created once we have a valid provider config
         self._logged_in_offline = False
 
@@ -544,7 +542,7 @@ class MainWindow(QtGui.QMainWindow, SignalTracker):
 
         # XXX: handle differently not logged in user?
         akm = AdvancedKeyManagement(self, mx_provided, logged_user,
-                                    self._backend, self._soledad_started)
+                                    self._backend, self.app.soledad_started)
         akm.show()
 
     def _show_preferences(self):
@@ -1238,7 +1236,7 @@ class MainWindow(QtGui.QMainWindow, SignalTracker):
         self._backend.soledad_cancel_bootstrap()
         self._backend.soledad_close()
 
-        self._soledad_started = False
+        self.app.soledad_started = True
 
     def _on_user_logged_in(self):
         """
@@ -1414,7 +1412,7 @@ class MainWindow(QtGui.QMainWindow, SignalTracker):
         """
         logger.debug("Done bootstrapping Soledad")
 
-        self._soledad_started = True
+        self.app.soledad_started = True
         self.soledad_ready.emit()
 
     ###################################################################

--- a/src/leap/bitmask/gui/passwordwindow.py
+++ b/src/leap/bitmask/gui/passwordwindow.py
@@ -210,7 +210,7 @@ class PasswordWindow(QtGui.QDialog, Flashable):
         # We need to implement rollaback.
 
         if self.is_soledad_needed():
-            self._backend.soledad_change_password(new_password=new_password)
+            self.app.backend.soledad_change_password(new_password=new_password)
         else:
             self._change_password_success()
 

--- a/src/leap/bitmask/gui/passwordwindow.py
+++ b/src/leap/bitmask/gui/passwordwindow.py
@@ -71,9 +71,10 @@ class PasswordWindow(QtGui.QDialog, Flashable):
             self.ui.cancel_button.setEnabled(True)
             self.flash_error(self.tr("Please log in to change your password."))
 
-        if self.is_soledad_needed() and not self._soledad_ready:
+        if self.is_soledad_needed() and not self.app.soledad_started:
             self._enable_password_widgets(False)
             self.ui.cancel_button.setEnabled(True)
+
             self.flash_message(
                 self.tr("Please wait for data storage to be ready."))
 
@@ -146,7 +147,6 @@ class PasswordWindow(QtGui.QDialog, Flashable):
         sig.soledad_password_change_error.connect(
             self._soledad_change_password_problem)
 
-        self._soledad_ready = False
         sig.soledad_bootstrap_finished.connect(self._on_soledad_ready)
 
     def _change_password(self):
@@ -269,4 +269,3 @@ class PasswordWindow(QtGui.QDialog, Flashable):
             Signaler.soledad_bootstrap_finished
         """
         self._enable_password_widgets(True)
-        self._soledad_ready = True

--- a/src/leap/bitmask/gui/preferenceswindow.py
+++ b/src/leap/bitmask/gui/preferenceswindow.py
@@ -70,7 +70,7 @@ class PreferencesWindow(QtGui.QDialog):
 
         # only allow a single preferences window at a time.
         if PreferencesWindow._current_window is not None:
-            PreferencesWindow._current_window.close_window()
+            PreferencesWindow._current_window.close()
         PreferencesWindow._current_window = self
 
     def _add_icons(self):


### PR DESCRIPTION
Connecting to the `soledad_bootstrap_finished` signal is not enough
since the password change window is created after the signal is emitted,
that way we were not able to tell when soledad is ready to be used.

- Resolves: #7474