### PR TITLE
[bug] remove bubble argument from the logbook NullHandler

### DIFF
--- a/changes/bug-logbook_handler_bubble
+++ b/changes/bug-logbook_handler_bubble
@@ -1,0 +1,1 @@
+- Remove bubble argument from the logbook NullHandler

--- a/src/leap/bitmask/logs/utils.py
+++ b/src/leap/bitmask/logs/utils.py
@@ -55,7 +55,7 @@ def get_logger(perform_rollover=False):
         level = logbook.NOTSET
 
     # This handler consumes logs not handled by the others
-    null_handler = logbook.NullHandler(bubble=False)
+    null_handler = logbook.NullHandler()
     null_handler.push_application()
 
     silencer = SelectiveSilencerFilter()


### PR DESCRIPTION
NullHandler doesn't have anymore the argument bubble.
https://pythonhosted.org/Logbook/changelog.html#version-0-11-0