### PR TITLE
[bug] move assign to prevent race condition

### DIFF
--- a/changes/bug-7451_missing-attribute
+++ b/changes/bug-7451_missing-attribute
@@ -1,0 +1,1 @@
+- Assign the timeout 'call later' before starting the sync to prevent race conditions. Related to #7451.

--- a/src/leap/bitmask/services/soledad/soledadbootstrapper.py
+++ b/src/leap/bitmask/services/soledad/soledadbootstrapper.py
@@ -623,10 +623,10 @@ class Syncer(object):
         logger.debug("BOOTSTRAPPER: trying to sync Soledad....")
         # pass defer_decryption=False to get inline decryption
         # for debugging.
-        self._sync_deferred = self._soledad.sync(defer_decryption=True)
-        self._sync_deferred.addCallbacks(self._success, self._error)
         self._timeout_delayed_call = reactor.callLater(self.WAIT_MAX_SECONDS,
                                                        self._timeout)
+        self._sync_deferred = self._soledad.sync(defer_decryption=True)
+        self._sync_deferred.addCallbacks(self._success, self._error)
 
     def _success(self, result):
         logger.debug("Soledad has been synced!")


### PR DESCRIPTION
When the error happens too quickly, the errback is called before the
assign of the callLater. And in the errback we cancel that call which
gives an error.

- Related: #7451