### PR TITLE
Bug/7512 use right config path

### DIFF
--- a/changes/bug-7512_use-right-config-path
+++ b/changes/bug-7512_use-right-config-path
@@ -1,0 +1,3 @@
+- Store zmq certs in the right path. Related #7512.
+- Store logs in the right place. Related #7512.
+- Pass on standalone flag to common. Related #7512.

--- a/src/leap/bitmask/app.py
+++ b/src/leap/bitmask/app.py
@@ -63,6 +63,8 @@ from leap.bitmask.services.mail import plumber
 from leap.bitmask.util import leap_argparse, flags_to_dict, here
 from leap.bitmask.util.requirement_checker import check_requirements
 
+from leap.common.config import flags as common_flags
+
 from leap.mail import __version__ as MAIL_VERSION
 
 import codecs
@@ -171,6 +173,8 @@ def start_app():
     flags.CA_CERT_FILE = opts.ca_cert_file
 
     flags.DEBUG = opts.debug
+
+    common_flags.STANDALONE = flags.STANDALONE
 
     logger = get_logger(perform_rollover=True)
 

--- a/src/leap/bitmask/backend/utils.py
+++ b/src/leap/bitmask/backend/utils.py
@@ -36,7 +36,14 @@ from leap.common.check import leap_assert
 
 logger = get_logger()
 
-KEYS_DIR = os.path.join(get_path_prefix(), 'leap', 'zmq_certificates')
+
+def _get_keys_dir():
+    """
+    Return the path where the ZMQ certificates should be stored.
+
+    :rtype: str
+    """
+    return os.path.join(get_path_prefix(), 'leap', 'zmq_certificates')
 
 
 def _zmq_has_curve():
@@ -79,17 +86,18 @@ def generate_zmq_certificates():
     """
     leap_assert(flags.ZMQ_HAS_CURVE, "CurveZMQ not supported!")
 
+    keys_dir = _get_keys_dir()
     # Create directory for certificates, remove old content if necessary
-    if os.path.exists(KEYS_DIR):
-        shutil.rmtree(KEYS_DIR)
-    mkdir_p(KEYS_DIR)
+    if os.path.exists(keys_dir):
+        shutil.rmtree(keys_dir)
+    mkdir_p(keys_dir)
     # set permissions to: 0700 (U:rwx G:--- O:---)
-    os.chmod(KEYS_DIR, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
+    os.chmod(keys_dir, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
 
     # create new keys in certificates dir
     # public_file, secret_file = create_certificates(...)
-    zmq.auth.create_certificates(KEYS_DIR, "frontend")
-    zmq.auth.create_certificates(KEYS_DIR, "backend")
+    zmq.auth.create_certificates(keys_dir, "frontend")
+    zmq.auth.create_certificates(keys_dir, "backend")
 
 
 def get_frontend_certificates():
@@ -98,7 +106,8 @@ def get_frontend_certificates():
     """
     leap_assert(flags.ZMQ_HAS_CURVE, "CurveZMQ not supported!")
 
-    frontend_secret_file = os.path.join(KEYS_DIR, "frontend.key_secret")
+    keys_dir = _get_keys_dir()
+    frontend_secret_file = os.path.join(keys_dir, "frontend.key_secret")
     public, secret = zmq.auth.load_certificate(frontend_secret_file)
     return public, secret
 
@@ -109,7 +118,8 @@ def get_backend_certificates(base_dir='.'):
     """
     leap_assert(flags.ZMQ_HAS_CURVE, "CurveZMQ not supported!")
 
-    backend_secret_file = os.path.join(KEYS_DIR, "backend.key_secret")
+    keys_dir = _get_keys_dir()
+    backend_secret_file = os.path.join(keys_dir, "backend.key_secret")
     public, secret = zmq.auth.load_certificate(backend_secret_file)
     return public, secret
 
@@ -120,8 +130,9 @@ def _certificates_exist():
 
     :rtype: bool
     """
-    frontend_secret_file = os.path.join(KEYS_DIR, "frontend.key_secret")
-    backend_secret_file = os.path.join(KEYS_DIR, "backend.key_secret")
+    keys_dir = _get_keys_dir()
+    frontend_secret_file = os.path.join(keys_dir, "frontend.key_secret")
+    backend_secret_file = os.path.join(keys_dir, "backend.key_secret")
     return os.path.isfile(frontend_secret_file) and \
         os.path.isfile(backend_secret_file)
 

--- a/src/leap/bitmask/backend_app.py
+++ b/src/leap/bitmask/backend_app.py
@@ -22,6 +22,7 @@ import signal
 
 from twisted.internet import reactor
 
+from leap.common.config import flags as common_flags
 from leap.common.events import server as event_server
 
 from leap.bitmask.backend.leapbackend import LeapBackend
@@ -69,6 +70,8 @@ def run_backend(bypass_checks=False, flags_dict=None, frontend_pid=None):
 
     if flags_dict is not None:
         dict_to_flags(flags_dict)
+
+    common_flags.STANDALONE = flags.STANDALONE
 
     # NOTE: this needs to be used here, within the call since this function is
     # executed in a different process and it seems that the process/thread

--- a/src/leap/bitmask/backend_app.py
+++ b/src/leap/bitmask/backend_app.py
@@ -67,13 +67,13 @@ def run_backend(bypass_checks=False, flags_dict=None, frontend_pid=None):
     observer = PythonLoggingObserver()
     observer.start()
 
+    if flags_dict is not None:
+        dict_to_flags(flags_dict)
+
     # NOTE: this needs to be used here, within the call since this function is
     # executed in a different process and it seems that the process/thread
     # identification isn't working 100%
     logger = get_logger()  # noqa
-
-    if flags_dict is not None:
-        dict_to_flags(flags_dict)
 
     # The backend is the one who always creates the certificates. Either if it
     # is run separately or in a process in the same app as the frontend.

--- a/src/leap/bitmask/backend_app.py
+++ b/src/leap/bitmask/backend_app.py
@@ -72,6 +72,9 @@ def run_backend(bypass_checks=False, flags_dict=None, frontend_pid=None):
     # identification isn't working 100%
     logger = get_logger()  # noqa
 
+    if flags_dict is not None:
+        dict_to_flags(flags_dict)
+
     # The backend is the one who always creates the certificates. Either if it
     # is run separately or in a process in the same app as the frontend.
     if flags.ZMQ_HAS_CURVE:
@@ -80,9 +83,6 @@ def run_backend(bypass_checks=False, flags_dict=None, frontend_pid=None):
     # ignore SIGINT since app.py takes care of signaling SIGTERM to us.
     signal.signal(signal.SIGINT, signal.SIG_IGN)
     signal.signal(signal.SIGTERM, signal_handler)
-
-    if flags_dict is not None:
-        dict_to_flags(flags_dict)
 
     reactor.callWhenRunning(start_events_and_updater, logger)
 

--- a/src/leap/bitmask/frontend_app.py
+++ b/src/leap/bitmask/frontend_app.py
@@ -31,10 +31,8 @@ from leap.bitmask.gui.mainwindow import MainWindow
 from leap.bitmask.logs.utils import get_logger
 from leap.bitmask.util import dict_to_flags
 
-logger = get_logger()
 
-
-def signal_handler(window, pid, signum, frame):
+def signal_handler(window, pid, logger, signum, frame):
     """
     Signal handler that quits the running app cleanly.
 
@@ -42,6 +40,8 @@ def signal_handler(window, pid, signum, frame):
     :type window: MainWindow
     :param pid: process id of the main process.
     :type pid: int
+    :param logger: the logger object to use for logging
+    :type logger: logbook.Logger
     :param signum: number of the signal received (e.g. SIGINT -> 2)
     :type signum: int
     :param frame: current stack frame
@@ -70,6 +70,7 @@ def run_frontend(options, flags_dict, backend_pid=None):
     :type flags_dict: dict
     """
     dict_to_flags(flags_dict)
+    logger = get_logger()
 
     start_hidden = options["start_hidden"]
 
@@ -120,7 +121,7 @@ def run_frontend(options, flags_dict, backend_pid=None):
     window = MainWindow(start_hidden=start_hidden, backend_pid=backend_pid)
 
     my_pid = os.getpid()
-    sig_handler = partial(signal_handler, window, my_pid)
+    sig_handler = partial(signal_handler, window, my_pid, logger)
     signal.signal(signal.SIGINT, sig_handler)
     signal.signal(signal.SIGTERM, sig_handler)
 

--- a/src/leap/bitmask/logs/utils.py
+++ b/src/leap/bitmask/logs/utils.py
@@ -37,19 +37,18 @@ from logbook.more import ColorizedStderrHandler
 from logbook.queues import ZeroMQSubscriber
 
 
-# NOTE: make sure that the folder exists, the logger is created before saving
-# settings on the first run.
-_base = os.path.join(get_path_prefix(), "leap")
-mkdir_p(_base)
-BITMASK_LOG_FILE = os.path.join(_base, 'bitmask.log')
-
-
 def get_logger(perform_rollover=False):
     """
     Push to the app stack the needed handlers and return a Logger object.
 
     :rtype: logbook.Logger
     """
+    # NOTE: make sure that the folder exists, the logger is created before
+    # saving settings on the first run.
+    _base = os.path.join(get_path_prefix(), "leap")
+    mkdir_p(_base)
+    bitmask_log_file = os.path.join(_base, 'bitmask.log')
+
     level = logbook.WARNING
     if flags.DEBUG:
         level = logbook.NOTSET
@@ -65,7 +64,7 @@ def get_logger(perform_rollover=False):
     zmq_handler.push_application()
 
     file_handler = logbook.RotatingFileHandler(
-        BITMASK_LOG_FILE, format_string=LOG_FORMAT, bubble=True,
+        bitmask_log_file, format_string=LOG_FORMAT, bubble=True,
         filter=silencer.filter, max_size=sys.maxint)
 
     if perform_rollover:


### PR DESCRIPTION
Apply several changes need to use the right config folder when bitmask is run as standalone.

Resolves: #7512

NOTE: https://github.com/leapcode/leap_pycommon/pull/125 is needed