### PR TITLE
[bug] use gpg2 binary if gpg not found. Closes: #7563

### DIFF
--- a/changes/next-changelog.rst
+++ b/changes/next-changelog.rst
@@ -17,6 +17,7 @@ Features
 Bugfixes
 ~~~~~~~~
 - `#7562 <https://leap.se/code/issues/7562>`_: use zmq embedded minitornado, instead of system lib.
+- `#7563 <https://leap.se/code/issues/7563>`_: use gpg2 binary if gpg not found
 - `#1235 <https://leap.se/code/issues/1235>`_: Description for the fixed stuff corresponding with issue #1235.
 - Bugfix without related issue number.
 

--- a/src/leap/bitmask/services/soledad/soledadbootstrapper.py
+++ b/src/leap/bitmask/services/soledad/soledadbootstrapper.py
@@ -444,7 +444,20 @@ class SoledadBootstrapper(AbstractBootstrapper):
         if IS_MAC:
             gpgbin = os.path.abspath(
                 os.path.join(here(), "apps", "mail", "gpg"))
-        leap_check(gpgbin is not None, "Could not find gpg binary")
+        if gpgbin is None:
+            try:
+                gpgbin_options = which("gpg2")
+                # gnupg checks that the path to the binary is not a
+                # symlink, so we need to filter those and come up with
+                # just one option.
+                for opt in gpgbin_options:
+                    if not os.path.islink(opt):
+                        gpgbin = opt
+                        break
+            except IndexError as e:
+                logger.debug("Couldn't find the gpg2 binary!")
+                logger.exception(e)
+        leap_check(gpgbin is not None, "Could not find gpg2 binary")
         return gpgbin
 
     def _init_keymanager(self, address, token):


### PR DESCRIPTION
from debian stretch on, gpg will be a symlink to gpg2.
this is currently failing if one uses dpkg-divert to make gpg2 provide
/usr/bin/gpg.

this solution just attempts to use gpg2 binary if the search for gpg
binary fails.

- Resolves: #7563
- Releases: 0.9.1