### PR TITLE
[feat] improve msg and add margin above box

### DIFF
--- a/changes/next-changelog.rst
+++ b/changes/next-changelog.rst
@@ -10,6 +10,7 @@ I've added a new category `Misc` so we can track doc/style/packaging stuff.
 
 Features
 ~~~~~~~~
+- `#7552 <https://leap.se/code/issues/7552>`_: Improve UI message and add some margin above the msg box.
 - `#1234 <https://leap.se/code/issues/1234>`_: Description of the new feature corresponding with issue #1234.
 - New feature without related issue number.
 

--- a/src/leap/bitmask/gui/ui/mail_status.ui
+++ b/src/leap/bitmask/gui/ui/mail_status.ui
@@ -77,7 +77,8 @@
        </property>
        <property name="styleSheet">
         <string notr="true">background-color: #e0efd8;
-padding: 10px;</string>
+padding: 10px;
+margin-top:5px;</string>
        </property>
        <property name="frameShape">
         <enum>QFrame::NoFrame</enum>
@@ -89,7 +90,7 @@ padding: 10px;</string>
         <number>0</number>
        </property>
        <property name="text">
-        <string>Congratulations! You are ready to use Bitmask to encrypt your email. Go to &lt;a href=&quot;https://bitmask.net/en/help/email&quot;&gt;https://bitmask.net/en/help/email&lt;/a&gt; for instructions on how to set up your mail client.</string>
+        <string>Bitmask is ready to encrypt your email. Go to &lt;a href=&quot;https://bitmask.net/en/help/email&quot;&gt;https://bitmask.net/en/help/email&lt;/a&gt; for email application setup instructions.</string>
        </property>
        <property name="textFormat">
         <enum>Qt::AutoText</enum>


### PR DESCRIPTION
Changed text to what mcnair suggested on issue 7552 and added a small margin above the box to have some separation between the sync/mail status and the instructions message.

- Related: #7552