### PR TITLE
[bug] frozen backend fails to spawn on windows

### DIFF
--- a/src/leap/bitmask/app.py
+++ b/src/leap/bitmask/app.py
@@ -237,4 +237,5 @@ def start_app():
 
 
 if __name__ == "__main__":
+    multiprocessing.freeze_support()
     start_app()


### PR DESCRIPTION
according to [1] the backend should raise a Runtime Error, instead what happens is that the process is spawned again and again but never runs actual code. 

[1] https://docs.python.org/2.7/library/multiprocessing.html#multiprocessing.freeze_support