### PR TITLE
[feat] use same token for imap/smtp authentication

### DIFF
--- a/src/leap/bitmask/backend/components.py
+++ b/src/leap/bitmask/backend/components.py
@@ -806,11 +806,8 @@ class Soledad(object):
                     (service, token))
 
         sol = self._soledad_bootstrapper.soledad
-        d = sol.get_or_create_service_token('imap')
-        d.addCallback(register_service_token, 'imap')
-        d.addCallback(
-            lambda _: sol.get_or_create_service_token('smtp'))
-        d.addCallback(register_service_token, 'smtp')
+        d = sol.get_or_create_service_token('mail_auth')
+        d.addCallback(register_service_token, 'mail_auth')
         d.addCallback(lambda _: result)
         return d
 

--- a/src/leap/bitmask/gui/mainwindow.py
+++ b/src/leap/bitmask/gui/mainwindow.py
@@ -1089,12 +1089,11 @@ class MainWindow(QtGui.QMainWindow, SignalTracker):
 
         # FIXME on i3, this doens't allow to mouse-select.
         # Switch to a dialog in which we can set the QLabel
-        imap_token = (self._service_tokens.get('imap', None) or
-                      "??? (log in to unlock)")
-        smtp_token = (self._service_tokens.get('smtp', None) or
-                      "??? (log in to unlock)")
-        imap_password = self.tr("IMAP Password:") + " %s" % (imap_token,)
-        smtp_password = self.tr("SMTP Password:") + " %s" % (smtp_token,)
+        mail_auth_token = (
+            self._service_tokens.get('mail_auth', None) or
+            "??? (log in to unlock)")
+        mail_password = self.tr("IMAP/SMTP Password:") + " %s" % (
+            mail_auth_token,)
 
         msg = help_url + self.tr(
             "<p><strong>{0}</strong></p>"
@@ -1105,10 +1104,9 @@ class MainWindow(QtGui.QMainWindow, SignalTracker):
             "<li>&nbsp;{4}</li>"
             "<li>&nbsp;{5}</li>"
             "<li>&nbsp;{6}</li>"
-            "<li>&nbsp;{7}</li>"
             "</ul></p>").format(email_quick_reference, thunderbird_text,
                                 manual_text, manual_imap, manual_smtp,
-                                manual_username, imap_password, smtp_password)
+                                manual_username, mail_password)
         QtGui.QMessageBox.about(self, self.tr("Bitmask Help"), msg)
 
     def _needs_update(self):


### PR DESCRIPTION
This greatly simplifies the handling of the password in the thunderbird
extension.

- Related: #6041