### PR TITLE
[bug] let the failure propagate

### DIFF
--- a/src/leap/bitmask/services/mail/imap.py
+++ b/src/leap/bitmask/services/mail/imap.py
@@ -94,5 +94,4 @@ def start_incoming_mail_service(keymanager, soledad, userid):
     acc = Account(soledad, userid)
     d = acc.callWhenReady(lambda _: acc.get_collection_by_mailbox(INBOX_NAME))
     d.addCallback(setUpIncomingMail)
-    d.addErrback(log.err)
     return d


### PR DESCRIPTION
The failure was processed in start_incoming_mail_service what will make
it return a None when an IncomingMail object was expected. If we
propagate the failure it can be treated properly by the IMAPController.

- Related: #8051