### PR TITLE
Fix keyring_helpers would not work with python-keyring >= 0.8

### DIFF
--- a/src/leap/bitmask/util/keyring_helpers.py
+++ b/src/leap/bitmask/util/keyring_helpers.py
@@ -19,11 +19,15 @@ Keyring helpers.
 """
 try:
     import keyring
-    from keyring.backends.file import EncryptedKeyring, PlaintextKeyring
-    OBSOLETE_KEYRINGS = [
-        EncryptedKeyring,
-        PlaintextKeyring
-    ]
+    try:
+        from keyring.backends.file import EncryptedKeyring, PlaintextKeyring
+        OBSOLETE_KEYRINGS = [EncryptedKeyring, PlaintextKeyring]
+    except ImportError:
+        try:
+            from keyrings.alt.file import EncryptedKeyring, PlaintextKeyring
+            OBSOLETE_KEYRINGS = [EncryptedKeyring, PlaintextKeyring]
+        except ImportError:
+            OBSOLETE_KEYRINGS = []
     canuse = lambda kr: (
         kr is not None and
         kr.__class__ not in OBSOLETE_KEYRINGS)


### PR DESCRIPTION
In `python-keyring` 0.8 they extracted the old backends into a separate
module called `keyrings.alt`, that has to be installed separately.  The
code was failing to load them and was silently assuming that there was
a failure loading the keyring library.

We fix the problem by trying to find the depecrated backends in the new
location if the old one fails.  If the second one fails (because
`python-keyring` is recent but the user did not install the deprecated
backends) we just fallback to not check for depecrated backends.

In fact, since with the new versions the user has to explicitly install
the deprecated backends, I wonder whether the whole business of
preventing them to be selected makes sense anymore...
