### PR TITLE
[bug] fix issues connecting to VPN when using openvpn 2.4

### DIFF
--- a/changes/next-changelog.rst
+++ b/changes/next-changelog.rst
@@ -20,6 +20,7 @@ Bugfixes
 ~~~~~~~~
 - `#1235 <https://leap.se/code/issues/1235>`_: Description for the fixed stuff corresponding with issue #1235.
 - Bugfix without related issue number.
+- `#8703 <https://leap.se/code/issues/8703>`_: Fix issues connecting to VPN when using openvpn 2.4 #8703.
 
 Misc
 ~~~~

--- a/src/leap/bitmask/services/eip/vpnprocess.py
+++ b/src/leap/bitmask/services/eip/vpnprocess.py
@@ -653,18 +653,30 @@ class VPNManager(object):
         Parses the output of the state command and emits state_changed
         signal when the state changes.
 
+        As of openvpn 2.4, the return of the state command changes
+        based on what state openvpn is in. Since we only care about
+        the first two fields, and these two are the same no matter the
+        state, only those two are pulled into variables.
+
+        See
+        https://github.com/OpenVPN/openvpn/blob/release/2.4/doc/management-notes.txt
+        for more information.
+        TODO: Change this link to an actual link to the docs when the
+        2.4 version shows up on the openvpn site.
+
         :param output: list of lines that the state command printed as
                        its output
         :type output: list
+
         """
         for line in output:
             stripped = line.strip()
             if stripped == "END":
                 continue
             parts = stripped.split(",")
-            if len(parts) < 5:
+            if len(parts) < 2:
                 continue
-            ts, status_step, ok, ip, remote = parts
+            ts, status_step = parts[:2]
 
             state = status_step
             if state != self._last_state:


### PR DESCRIPTION
OpenVPN 2.4 changed the format of the output of the state command. The
meaning and number of fields now changes based on the state. Since the
second field is the only one actually used, we truncate the returned
values after it.

- Resolves: #8703