### PR TITLE
[feat] show units other than KB in VPN status when useful

### DIFF
--- a/changes/next-changelog.rst
+++ b/changes/next-changelog.rst
@@ -12,6 +12,7 @@ Features
 ~~~~~~~~
 - `#7965 <https://leap.se/code/issues/7965>`_: Add basic keymanagement to the cli.
 - Use mail_auth token in the core instead of imap/smtp tokens.
+- `#3255 <https://leap.se/code/issues/3255>`_: Show units other than KB in VPN status when revevant.
 
 - `#1234 <https://leap.se/code/issues/1234>`_: Description of the new feature corresponding with issue #1234.
 - New feature without related issue number.

--- a/src/leap/bitmask/gui/eip_status.py
+++ b/src/leap/bitmask/gui/eip_status.py
@@ -39,8 +39,6 @@ class EIPStatusWidget(QtGui.QWidget):
     EIP Status widget that displays the current state of the EIP service
     """
     DISPLAY_TRAFFIC_RATES = True
-    RATE_STR = "%1.2f KB/s"
-    TOTAL_STR = "%1.2f Kb"
 
     def __init__(self, parent, eip_conductor, leap_signaler):
         """
@@ -156,8 +154,8 @@ class EIPStatusWidget(QtGui.QWidget):
         self._up_rate = RateMovingAverage()
         self._down_rate = RateMovingAverage()
 
-        self.ui.btnUpload.setText(self.RATE_STR % (0,))
-        self.ui.btnDownload.setText(self.RATE_STR % (0,))
+        self.ui.btnUpload.setText('%s/s' % self._format_bytes(0))
+        self.ui.btnDownload.setText('%s/s' % self._format_bytes(0))
 
     def _reset_traffic_rates(self):
         """
@@ -519,16 +517,38 @@ class EIPStatusWidget(QtGui.QWidget):
 
         if self.DISPLAY_TRAFFIC_RATES:
             uprate, downrate = self._get_traffic_rates()
-            upload_str = self.RATE_STR % (uprate,)
-            download_str = self.RATE_STR % (downrate,)
+            upload_str = '%s/s' % self._format_bytes(uprate)
+            download_str = '%s/s' % self._format_bytes(downrate)
 
         else:  # display total throughput
             uptotal, downtotal = self._get_traffic_totals()
-            upload_str = self.TOTAL_STR % (uptotal,)
-            download_str = self.TOTAL_STR % (downtotal,)
+            upload_str = self._format_bytes(uptotal)
+            download_str = self._format_bytes(downtotal)
 
         self.ui.btnUpload.setText(upload_str)
         self.ui.btnDownload.setText(download_str)
+
+    def _format_bytes(self, _bytes):
+        """
+        Formats a number of bytes in a human readable way. Uses KB, MB,
+        GB, or TB depending on the number of bytes.
+
+        :param _bytes: A float with the number of bytes
+        :type _bytes: float
+        :returns: A formatted string representing the number of bytes
+        :rtype: str
+        """
+        units = ['KB', 'MB', 'GB', 'TB']
+        adjusted_unit = None
+        adjusted_total = _bytes
+
+        for unit in units:
+            adjusted_unit = unit
+            adjusted_total /= 1000
+            if adjusted_total < 1000:
+                break
+
+        return "%1.2f %s" % (adjusted_total, adjusted_unit)
 
     def update_vpn_state(self, vpn_state):
         """

--- a/src/leap/bitmask/util/averages.py
+++ b/src/leap/bitmask/util/averages.py
@@ -72,7 +72,7 @@ class RateMovingAverage(object):
             deltat = 0
 
         try:
-            rate = float(deltatraffic) / float(deltat) / 1024
+            rate = float(deltatraffic) / float(deltat)
         except ZeroDivisionError:
             rate = 0
 
@@ -87,6 +87,6 @@ class RateMovingAverage(object):
         Gets the total accumulated throughput.
         """
         try:
-            return self._data[-1][1] / 1024
+            return self._data[-1][1]
         except TypeError:
             return 0


### PR DESCRIPTION
When total data transfered or current bandwith gets high, it can
become dificult to read the number. This switches to show MB when the
number passes 1000KB, GB when the number passes 100MB, and TB when the
number passes over 10000GB.

Resolves: #3255